### PR TITLE
[docs][powered by] add airbnb and chronos

### DIFF
--- a/docs/Powered-by-Mesos.md
+++ b/docs/Powered-by-Mesos.md
@@ -4,9 +4,11 @@ Organizations using Mesos:
 * [Conviva](http://www.conviva.com)
 * [UCSF](http://www.ucsf.edu)
 * [UC Berkeley](http://www.berkeley.edu)
+* [Airbnb](https://www.airbnb.com)
 
 Software projects built on Mesos:
 
 * [Spark](http://www.spark-project.org) cluster computing framework
+* [Chronos](http://airbnb.github.io/chronos/) distributed and fault-tolerant scheduler
 
 If you're using Mesos, please add yourself to the list above, or email dev@mesos.apache.org and we'll add you!


### PR DESCRIPTION
Was roaming around the docs and saw the "powered by" section and thought I'd add Airbnb and Chronos.
