### PR TITLE
added example form to attributes flag help message

### DIFF
--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -73,7 +73,8 @@ public:
 
     add(&Flags::attributes,
         "attributes",
-        "Attributes of machine");
+        "Attributes of machine, in the form:\n",
+        "rack:2 or 'rack:2,u:1'");
 
     add(&Flags::work_dir,
         "work_dir",


### PR DESCRIPTION
the previous message was vague and detail around the form is by trial and error.  Added examples to the attributes flag help message to be more informative to the user.