### PR TITLE
Clean help flags

### DIFF
--- a/src/logging/flags.hpp
+++ b/src/logging/flags.hpp
@@ -47,7 +47,7 @@ public:
 
     add(&Flags::log_dir,
         "log_dir",
-        "Location to put log files (no default, nothing\n"
+        "Directory path to put log files (no default, nothing\n"
         "is written to disk unless specified;\n"
         "does not affect logging to stderr)");
 

--- a/src/master/flags.hpp
+++ b/src/master/flags.hpp
@@ -61,7 +61,8 @@ public:
 
     add(&Flags::work_dir,
         "work_dir",
-        "Where to store the persistent information stored in the Registry.");
+        "Directory path to store the persistent information stored in the Registry.\n",
+        "(example: /tmp/meso )");
 
     // TODO(bmahler): Consider removing 'in_memory' as it was only
     // used before 'replicated_log' was implemented.
@@ -145,7 +146,7 @@ public:
 
     add(&Flags::webui_dir,
         "webui_dir",
-        "Location of the webui files/assets",
+        "Directory path of the webui files/assets",
         PKGDATADIR "/webui");
 
     add(&Flags::whitelist,

--- a/src/master/main.cpp
+++ b/src/master/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
             "May be one of:\n"
             "  zk://host1:port1,host2:port2,.../path\n"
             "  zk://username:password@host1:port1,host2:port2,.../path\n"
-            "  file://path/to/file (where file contains one of the above)");
+            "  file:///path/to/file (where file contains one of the above)");
 
   bool help;
   flags.add(&help,

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -77,17 +77,17 @@ public:
 
     add(&Flags::work_dir,
         "work_dir",
-        "Where to place framework work directories\n",
+        "Directory path to place framework work directories\n",
         "/tmp/mesos");
 
     add(&Flags::launcher_dir, // TODO(benh): This needs a better name.
         "launcher_dir",
-        "Location of Mesos binaries",
+        "Directory path of Mesos binaries",
         PKGLIBEXECDIR);
 
     add(&Flags::hadoop_home,
         "hadoop_home",
-        "Where to find Hadoop installed (for\n"
+        "Path to find Hadoop installed (for\n"
         "fetching framework executors from HDFS)\n"
         "(no default, look for HADOOP_HOME in\n"
         "environment or find hadoop on PATH)",
@@ -102,7 +102,7 @@ public:
 
     add(&Flags::frameworks_home,
         "frameworks_home",
-        "Directory prepended to relative executor URIs",
+        "Directory path prepended to relative executor URIs",
         "");
 
     add(&Flags::registration_backoff_factor,

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -108,7 +108,7 @@ public:
     add(&Flags::registration_backoff_factor,
         "registration_backoff_factor",
         "Slave initially picks a random amount of time between [0, b], where\n"
-        "b = register_backoff_factor, to (re-)register with a new master.\n"
+        "b = registration_backoff_factor, to (re-)register with a new master.\n"
         "Subsequent retries are exponentially backed off based on this\n"
         "interval (e.g., 1st retry uses a random value between [0, b * 2^1],\n"
         "2nd retry between [0, b * 2^2], 3rd retry between [0, b * 2^3] etc)\n"

--- a/src/slave/main.cpp
+++ b/src/slave/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
             "May be one of:\n"
             "  zk://host1:port1,host2:port2,.../path\n"
             "  zk://username:password@host1:port1,host2:port2,.../path\n"
-            "  file://path/to/file (where file contains one of the above)");
+            "  file:///path/to/file (where file contains one of the above)");
 
   bool help;
   flags.add(&help,


### PR DESCRIPTION
in the case of the zk flag.  the help is wrong.  The full file:/// protocol **must** be followed.  the way it is written, it appears as though you can just provide the absolute path, which fails.

The rest of it, cleans up the help to be more consistent with the phrasing.