### PR TITLE
Fix for MESOS-1688

### DIFF
--- a/src/master/hierarchical_allocator_process.hpp
+++ b/src/master/hierarchical_allocator_process.hpp
@@ -833,11 +833,8 @@ HierarchicalAllocatorProcess<RoleSorter, FrameworkSorter>::allocatable(
   Option<double> cpus = resources.cpus();
   Option<Bytes> mem = resources.mem();
 
-  if (cpus.isSome() || mem.isSome()) {
-    return cpus.get() >= MIN_CPUS || mem.get() > MIN_MEM;
-  }
-
-  return false;
+  return (cpus.isSome() && cpus.get() >= MIN_CPUS)
+    || (mem.isSome() && mem.get() > MIN_MEM);
 }
 
 } // namespace allocator {


### PR DESCRIPTION
As already explained in [MESOS-1688](https://issues.apache.org/jira/browse/MESOS-1688), there are schedulers allocating memory only for the executor and not for tasks. For tasks only CPU resources are allocated in this case.
Such a scheduler does not get offered any idle CPUs if the slave has nearly used up all memory.
This can easily lead to a dead lock (in the application, not in Mesos).

Simple example:
1. Scheduler allocates all memory of a slave for an executor
2. Scheduler launches a task for this executor (allocating 1 CPU)
3. Task finishes: 1 CPU , 0 MB memory allocatable.
4. No offers are made, as no memory is left. Scheduler will wait of offers forever. Dead lock in the application.

To fix this problem, offers must be made if either CPU or memory is allocatable.
