### PR TITLE
Update mpiexec-mesos.in

### DIFF
--- a/mpi/mpiexec-mesos.in
+++ b/mpi/mpiexec-mesos.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This is a wrapper script for the MPI launcher framework.
 #


### PR DESCRIPTION
In the if statement [[ is used - [[ is a bash builtin command and is not available in sh. It will give an error ( [[: not found ) unless /bin/sh is a symbolic link to /bin/bash