### PR TITLE
replace unsafe "find | xargs" with "find -exec"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1191,7 +1191,7 @@ endif # HAS_PYTHON
 
 clean-python:
 	find python -name "build" -o -name "dist" -o -name "*.pyc"		\
-		-o -name "*.egg-info" | xargs rm -rf
+		-o -name "*.egg-info" -exec rm -rf '{}' \+
 
 PHONY_TARGETS += clean-python
 

--- a/src/tests/balloon_framework_test.sh
+++ b/src/tests/balloon_framework_test.sh
@@ -44,7 +44,7 @@ function cleanup() {
   fi
 
   # Make sure we cleanup any cgroups we created on exiting.
-  find ${TEST_CGROUP_HIERARCHY}/*/${TEST_CGROUP_ROOT} -mindepth 1 -depth -type d | xargs -r rmdir
+  find ${TEST_CGROUP_HIERARCHY}/*/${TEST_CGROUP_ROOT} -mindepth 1 -depth -type d -exec rmdir '{}' \+
 
   # Make sure we cleanup the hierarchy, if we created it.
   # NOTE: We do a sleep here, to ensure the hierarchy is not busy.


### PR DESCRIPTION
The current `find | xargs rm -rf` in the Makefile could potentially destroy data if mesos source was in a folder with a space in the name. E.g. if you for some reason checkout mesos to `/ mesos` the command in src/Makefile.am would turn into a `rm -rf /`

`find | xargs` should be NUL delimited with `find -print0 | xargs -0` for safer execution or can just be replaced with the find build-in option `find -exec '{}' \+` which behaves similar to xargs.

Example:
```
$ touch somefile.txt
$ touch "file with spaces.txt"
$ find . -name "*.txt" | xargs -n 1 echo rm -rf
rm -rf ./file
rm -rf with
rm -rf spaces.txt
rm -rf ./somefile.txt
$ find . -name "*.txt" -exec echo rm -rf '{}' \;
rm -rf ./file with spaces.txt
rm -rf ./somefile.txt
```
(Note: for demonstration purposes `xargs -n 1` is similar to `find -exec '{}' \;` whereas `xargs` default behaviour is similar to `find -exec '{}'  \+`)

There was a second occurrence of this in a test script, though in that case it would only rmdir empty folders, so is less critical.