### PR TITLE
Build Mesos with OpenSSL flavour of libcurl - Mesospehere debs consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get install -yq build-essential autoconf libtool zlib1g-dev
-RUN apt-get install -yq libcurl4-nss-dev libsasl2-dev
+RUN apt-get install -yq libcurl4-openssl-dev libsasl2-dev
 RUN apt-get install -yq openjdk-6-jdk maven
 RUN apt-get install -yq python-dev python-boto
 RUN apt-get install -yq libsvn-dev libapr1-dev

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ Following are the instructions for stock Ubuntu 14.04. If you are using a differ
         $ sudo apt-get install -y autoconf libtool
 
         # Install other Mesos dependencies.
-        $ sudo apt-get -y install build-essential python-dev python-boto libcurl4-nss-dev libsasl2-dev maven libapr1-dev libsvn-dev
+        $ sudo apt-get -y install build-essential python-dev python-boto libcurl4-openssl-dev libsasl2-dev maven libapr1-dev libsvn-dev
 
 ### Mac OS X Yosemite
 

--- a/support/jenkins_build.sh
+++ b/support/jenkins_build.sh
@@ -53,7 +53,7 @@ case $OS in
     # Install dependencies.
     append_dockerfile "RUN apt-get update"
     append_dockerfile "RUN apt-get -y install build-essential clang git maven autoconf libtool"
-    append_dockerfile "RUN apt-get -y install openjdk-7-jdk python-dev python-boto libcurl4-nss-dev libsasl2-dev libapr1-dev libsvn-dev"
+    append_dockerfile "RUN apt-get -y install openjdk-7-jdk python-dev python-boto libcurl4-openssl-dev libsasl2-dev libapr1-dev libsvn-dev"
 
     # Add an unpriviliged user.
     append_dockerfile "RUN adduser --disabled-password --gecos '' mesos"


### PR DESCRIPTION
Deb packages from Mesospshere (https://mesosphere.com/downloads/) are build with OpenSSL flavour of *libcurl*.
Could we have Dockerfile that builds mesos in the same way?