### PR TITLE
MESOS-2424 FIX: protobuf installs latest setuptools in Mesos dist if …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update
 RUN apt-get install -yq build-essential autoconf libtool zlib1g-dev
 RUN apt-get install -yq libcurl4-nss-dev libsasl2-dev
 RUN apt-get install -yq openjdk-6-jdk maven
-RUN apt-get install -yq python-dev python-boto
+RUN apt-get install -yq python-dev python-setuptools python-boto
 RUN apt-get install -yq libsvn-dev libapr1-dev
 
 # export environment


### PR DESCRIPTION
…there's older one in build system OS https://github.com/google/protobuf/blob/v2.5.0/python/setup.py#L187