### PR TITLE
[MESOS-3170] Add $LIBS to build path of the CRAM-MD5 test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -837,7 +837,7 @@ __EOF__
 # distcheck failure on OSX by leaking build artefacts (.dsym).
 AS_IF([test "x${ac_cv_env_CFLAGS_set}" = "x"],
       [SASL_TEST_CFLAGS=""], [SASL_TEST_CFLAGS=$CFLAGS])
-$CC crammd5_installed.c $CPPFLAGS $SASL_TEST_CFLAGS $LDFLAGS -lsasl2  \
+$CC crammd5_installed.c $CPPFLAGS $SASL_TEST_CFLAGS $LDFLAGS -lsasl2 $LIBS \
   -o crammd5_installed 2>&1 >/dev/null
 
 # Run the test binary and get its output.


### PR DESCRIPTION
If the sasl2 library has been statically linked than the CRAM-MD5 check in the configure script can fail due to missing symbols. The correct approach is to add the required static lib archives into the LIBS variable. Adding this variable to the build action will allow the crammd5_installed.c check program compile and allow the check to pass.