### PR TITLE
Docker host (-H) support in slave

### DIFF
--- a/src/docker/docker.hpp
+++ b/src/docker/docker.hpp
@@ -42,7 +42,7 @@ class Docker
 {
 public:
   // Create Docker abstraction and optionally validate docker.
-  static Try<Docker*> create(const std::string& path, bool validate = true);
+  static Try<Docker*> create(const std::string& path, bool validate = true, const std::string& host = "unix:///var/run/docker.sock");
 
   virtual ~Docker() {}
 
@@ -151,7 +151,7 @@ public:
 
 protected:
   // Uses the specified path to the Docker CLI tool.
-  Docker(const std::string& _path) : path(_path) {};
+  Docker(const std::string& _path, const std::string& _host = "unix:///var/run/docker.sock") : path(_path), host(_host) {};
 
 private:
   static process::Future<Nothing> _run(
@@ -230,6 +230,9 @@ private:
       const std::string& cmd);
 
   const std::string path;
+
+public:  
+  const std::string host;
 };
 
 #endif // __DOCKER_HPP__

--- a/src/docker/executor.cpp
+++ b/src/docker/executor.cpp
@@ -406,7 +406,7 @@ int main(int argc, char** argv)
   // The 2nd argument for docker create is set to false so we skip
   // validation when creating a docker abstraction, as the slave
   // should have already validated docker.
-  Try<Docker*> docker = Docker::create(flags.docker.get(), false);
+  Try<Docker*> docker = Docker::create(flags.docker.get(), false, flags.docker_host.get());
   if (docker.isError()) {
     cerr << "Unable to create docker abstraction: " << docker.error() << endl;
     return EXIT_FAILURE;

--- a/src/docker/executor.hpp
+++ b/src/docker/executor.hpp
@@ -40,6 +40,10 @@ struct Flags : public mesos::internal::logging::Flags
         "docker",
         "The path to the docker executable.\n");
 
+    add(&docker_host,
+        "docker_host",
+        "The docker host.\n");
+
     add(&sandbox_directory,
         "sandbox_directory",
         "The path to the container sandbox holding stdout and stderr files\n"
@@ -57,6 +61,7 @@ struct Flags : public mesos::internal::logging::Flags
 
   Option<std::string> container;
   Option<std::string> docker;
+  Option<std::string> docker_host;
   Option<std::string> sandbox_directory;
   Option<std::string> mapped_directory;
   Option<Duration> stop_timeout;

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -121,10 +121,11 @@ Try<DockerContainerizer*> DockerContainerizer::create(
     const Flags& flags,
     Fetcher* fetcher)
 {
-  Try<Docker*> create = Docker::create(flags.docker);
+  Try<Docker*> create = Docker::create(flags.docker, true, flags.docker_host);
   if (create.isError()) {
     return Error("Failed to create docker: " + create.error());
   }
+
 
   Shared<Docker> docker(create.get());
 
@@ -185,6 +186,7 @@ docker::Flags dockerFlags(
   dockerFlags.sandbox_directory = directory;
   dockerFlags.mapped_directory = flags.sandbox_directory;
   dockerFlags.stop_timeout = flags.docker_stop_timeout;
+  dockerFlags.docker_host = flags.docker_host;
   return dockerFlags;
 }
 
@@ -821,6 +823,8 @@ Future<Docker::Container> DockerContainerizerProcess::launchExecutorContainer(
 
   Container* container = containers_[containerId];
   container->state = Container::RUNNING;
+
+  LOG(ERROR) << "The docker host is " << docker->host  << std::endl;
 
   // Start the executor in a Docker container.
   // This executor could either be a custom executor specified by an

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -390,6 +390,12 @@ mesos::internal::slave::Flags::Flags()
       "path used by the slave's docker image.\n",
       "/var/run/docker.sock");
 
+  add(&Flags::docker_host,
+      "docker_host",
+      "The docker host to be connected to\n"
+      "UNIX socket path of tcp host ip\n",
+      "unix:///var/run/docker.sock");
+
   add(&Flags::sandbox_directory,
       "sandbox_directory",
       "The absolute path for the directory in the container where the\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -97,6 +97,7 @@ public:
   Duration docker_stop_timeout;
   bool docker_kill_orphans;
   std::string docker_socket;
+  std::string docker_host;
 #ifdef WITH_NETWORK_ISOLATOR
   uint16_t ephemeral_ports_per_container;
   Option<std::string> eth0_name;


### PR DESCRIPTION
The docker daemon requires additional command lines options, which slave today do not support. One of the important is --host or -H, without this option slave shall only communicate to docker daemon on default port.