### PR TITLE
fix missing timeout in mesos-fetcher

### DIFF
--- a/3rdparty/libprocess/3rdparty/stout/include/stout/posix/net.hpp
+++ b/3rdparty/libprocess/3rdparty/stout/include/stout/posix/net.hpp
@@ -89,6 +89,8 @@ inline Try<Bytes> contentLength(const std::string& url)
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(curl, CURLOPT_HEADER, 1);
   curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 120);
 
   CURLcode curlErrorCode = curl_easy_perform(curl);
   if (curlErrorCode != 0) {
@@ -136,6 +138,8 @@ inline Try<int> download(const std::string& url, const std::string& path)
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 120);
 
   FILE* file = fdopen(fd.get(), "w");
   if (file == NULL) {


### PR DESCRIPTION
Added hardcoded timeout in mesos-fetcher code, following lots of issues with hanging connections, that would forbid the executor to proceed.

Notes:
- code tested on 0.22.0 (slighty different, just one place where the patch resides)
- duplicated hardcoded values (bad bad bad), make it configurable somehow ?
- code non compiled / tested, since MESOS_FETCHER_INFO variable content changes and I wasnt able to start a download with the old json string (despite adding sandbox_directory).

  