### PR TITLE
Process dispatch

### DIFF
--- a/3rdparty/libprocess/include/process/future.hpp
+++ b/3rdparty/libprocess/include/process/future.hpp
@@ -90,6 +90,8 @@ template <typename T>
 class Future
 {
 public:
+  typedef T value_type;
+
   // Constructs a failed future.
   static Future<T> failed(const std::string& message);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -706,6 +706,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
 	common/date_utils.hpp						\
 	common/http.hpp							\
 	common/parse.hpp						\
+	common/process_dispatcher.hpp					\
 	common/protobuf_utils.hpp					\
 	common/recordio.hpp						\
 	common/resources_utils.hpp					\

--- a/src/common/process_dispatcher.hpp
+++ b/src/common/process_dispatcher.hpp
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PROCESS_DISPATCHER_HPP__
+#define __PROCESS_DISPATCHER_HPP__
+
+#include <memory>
+#include <utility>
+
+#include <stout/try.hpp>
+
+#include <process/dispatch.hpp>
+#include <process/process.hpp>
+#include <process/shared.hpp>
+
+namespace mesos {
+
+template <typename I>
+class Dispatchable
+{
+public:
+  virtual ~Dispatchable(){}
+
+  template <typename Callable, typename ...Args>
+    auto dispatch(Callable fn, Args&&... args)
+    -> typename std::result_of<decltype(fn)(I*, Args...)>::type
+    {
+      ProcessBase* process = dynamic_cast<ProcessBase*>(getInterface());
+      return process::dispatch<I, Callable, Args...>(
+          process,
+          fn,
+          std::forward<Args>(args)...);
+    }
+
+protected:
+  void setInterface(const process::Shared<I>& i)
+  {
+    interface = i;
+  }
+
+  I* getInterface()
+  {
+    return const_cast<I*>(interface.get());
+  }
+
+  process::Shared<I> interface;
+};
+
+template <typename I, typename P = I>
+class ProcessDispatcher : public Dispatchable<I>
+{
+public:
+  template<typename ...Args>
+  static Try<process::Owned<Dispatchable<I>>> create(Args&&... args)
+  {
+    Try<process::Owned<P>> newProcess(P::create(std::forward<Args>(args)...));
+
+    if (newProcess.isError()) {
+      return Error(newProcess.error());
+    }
+
+    process::Shared<I> sharedInterface(newProcess.get().release());
+
+    return process::Owned<Dispatchable<I>>(
+        new ProcessDispatcher(sharedInterface));
+  }
+
+  static Try<process::Owned<ProcessDispatcher>> create(
+      process::Shared<I> process)
+  {
+    return(process::Owned<ProcessDispatcher>(new ProcessDispatcher(process)));
+  }
+
+  ~ProcessDispatcher()
+  {
+    ProcessBase* process = dynamic_cast<ProcessBase*>(this->getInterface());
+
+    terminate(process);
+    process::wait(process);
+  }
+
+private:
+  ProcessDispatcher(const process::Shared<I>& i)
+    :Dispatchable<I>()
+  {
+    this->setInterface(i);
+
+    ProcessBase* process = dynamic_cast<ProcessBase*>(const_cast<I*>(i.get()));
+    if (!process)
+    {
+      assert(false);
+    }
+
+    spawn(process);
+  }
+
+  ProcessDispatcher(const ProcessDispatcher&) = delete;
+};
+
+} // namespace mesos {
+
+#endif // __PROCESS_DISPATCHER_HPP__


### PR DESCRIPTION
## Generic Asynchronous Dispatcher   
## Motivation

  Since mesos code is based on the actor model and dispatching an interface  
asynchronously is a large part of the code base, generalizing the higher level concept of  
asynchronously dispatching an interface would eliminate the need to manually 
program the dispatch boilerplate.                                         

An example usage:  
For a simple interface like:                                                     

``` C
class Interface                                                                  
{                                                                                
  virtual Future<size_t> writeToFile(const char* data) = 0;                      
  virtual ~Interface();                                                          
};     
```

Today the developer has to do the following:                                     

a.  Write a wrapper class that implements the same interface to add the  
    dispatching boilerplate.  
b.  Spend precious time in reviews.  
c.  Risk introducing bugs.                                                       

  None of the above steps add any value to the executable binary.                

The wrapper class would look like:                                               

``` C

// -- hpp file                                                                   
class InterfaceProcess;                                                          

class InterfaceImpl : public Interface                                           
{                                                                                
public:                                                                          
  Try<Owned<InterfaceImpl>> create(const Flags& flags);                          

  virtual Future<size_t> writeToFile(const char* data);                          

  ~InterfaceImpl();
private:                                                                         
  Owned<InterfaceProcess> process;                                               
};                                                                               

// -- cpp file                                                                   
Try<Owned<InterfaceImpl>> create(const Flags& flags)                             
{                                                                                
  // Code to create the InterfaceProcess class.                                  
}                                                                                

Future Future<size_t> InterfaceImpl::writeToFile(const char* data)               
{                                                                                
  process->dispatch(                                                             
    &InterfaceProcess::writeToFile,                                              
    data);                                                                       
}                                                                                

InterfaceImpl::InterfaceImpl()                                                   
{                                                                                
  // Code to spawn the process                                                   
}                                                                                

InterfaceImpl::~InterfaceImpl()                                                  
{                                                                                
  // Code to stop the process.                                                   
}   
```

At the caller/client site, the code would look like:                             

``` C
Try<Owned<Interface>> in = InterfaceImpl::create(flags);                         
Future<size_t> result =                                                          
  in->writeToFile(data);                                                                       
```
## Proposal                                                                         

  We should use C++'s rich language semnatics to express the intent and avoid  
the boilerplate we write manually.  
  The basic intent of the code that leads to all the boilerplate above is:       

a. An interface that provides a set of functionality.  
b. An implementation of the interface.  
c. Ability to dispatch that interface asynchronously using actor.                

C++ has a rich set of generics that can be used to express above.                
## Components                                                                       
1. ProcessDispatcher  
   This component will "dispatch" an interface implementation asychronously using 
   the process framework.  
   This component can be expressed as:                                            
   
   ``` C
   ProcessDispatcher<Interface, InterfaceImplmentation>   
   ```
2. DispatchInterface  
   Any interface that provides an implementation that can be "dispatched" can be  
   expressed using this component.  
   This component can be expressed as:                                            

``` C
Dispatchable<Interface>  
```
## Usage:
1. Simple usage  

``` C
Try<Owned<Dispatchable<Interface>>> dispatcher =                                 
  ProcessDispatcher<Interface, InterfaceImpl>::create(flags);                    

Future<size_t> result =                                                          
  dispatcher->dispatch(                                                          
    Interface::writeToFile,                                                      
    data);                                                                       
```
1. Collecting the interface in a container                                       
   
   ``` C
   vector<Owned<Dispatchable<Interface>>> dispatchCollection;                       
   
   Try<Owned<Dispatchable<Interface>>> dispatcher1 =                                
   ProcessDispatcher<Interface, InterfaceImpl1>::create(flags);                   
   
   Try<Owned<Dispatchable<Interface>>> dispatcher2 =                                
   ProcessDispatcher<Interface, InterfaceImpl2>::create("test");                  
   
   dispatchCollection.push_back(dispatcher1);                                       
   dispatchCollection.push_back(dispatcher2);    
   
   ```

The advantages of using the generic dispatcher:
- Saves time by avoiding to write all the boilerplate and going through review  
  cycles.  
- Less bugs.  
- Focus on real problem and not boilerplate.  
- Less code to represent a primitive.  
