### PR TITLE
Insert version number for 0.23.0 in CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -149,6 +149,8 @@ This release also includes several bug fixes and stability improvements.
 ** Wish
     * [MESOS-3276] - Add Scrapinghub to the Powered By Mesos page
 
+
+Release Notes - Mesos - Version 0.23.0
 --------------------------------------------
 This release contains new features:
 


### PR DESCRIPTION
The CHANGELOG is missing the Mesos version number for the 0.23.0 section.
This commit adds the proper section topic.