### PR TITLE
update module doc:  add parameter -c to build command

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -272,7 +272,7 @@ mesos::modules::Module<TestModule> org_apache_mesos_TestModule(
   The following assumes that Mesos is installed in the standard location, i.e.
   the Mesos dynamic library and header files are available.
 
-    g++ -lmesos -fpic -o test_module.o test_module.cpp
+    g++ -lmesos -fpic -c -o test_module.o test_module.cpp
     $ gcc -shared -o libtest_module.so test_module.o
 
 ### Testing a modules


### PR DESCRIPTION
without -c parameter, get error:

/usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../lib64/crt1.o: In function `_start':
(.text+0x20): undefined reference to`main'
collect2: error: ld returned 1 exit status
