### PR TITLE
Patch Docker containerizer for container name

### DIFF
--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -110,7 +110,11 @@ Option<ContainerID> parse(const Docker::Container& container)
     vector<string> parts = strings::split(name.get(), DOCKER_NAME_SEPERATOR);
     if (parts.size() == 2 || parts.size() == 3) {
       ContainerID id;
-      id.set_value(parts[1]);
+
+      // set id equal to 'slaveID.containerId`
+      std::ostringstream oss;
+      oss << parts[0] << "." << parts[1];
+      id.set_value(oss.str());
       return id;
     }
   }


### PR DESCRIPTION
Use 'slaveId.containerId' for Docker slave recovery. This should close https://issues.apache.org/jira/browse/MESOS-3808

@tnachen It looks like you worked on this bit of code last. Please provide any thoughts.
