### PR TITLE
Update ElasticSearch repo

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -31,6 +31,6 @@ layout: documentation
 ## Data Storage
 
 * [Cassandra](https://github.com/mesosphere/cassandra-mesos) is a performant and highly available distributed database. Linear scalability and proven fault-tolerance on commodity hardware or cloud infrastructure make it the perfect platform for mission-critical data.
-* [ElasticSearch](https://github.com/mesosphere/elasticsearch-mesos) is a distributed search engine. Mesos makes it easy to run and scale.
+* [ElasticSearch](https://github.com/mesos/elasticsearch) is a distributed search engine. Mesos makes it easy to run and scale.
 * [Hypertable](https://code.google.com/p/hypertable/wiki/Mesos) is a high performance, scalable, distributed storage and processing system for structured and unstructured data.
 * [Tachyon](http://tachyon-project.org) is a memory-centric distributed storage system enabling reliable data sharing at memory-speed across cluster frameworks.


### PR DESCRIPTION
https://github.com/mesosphere/elasticsearch-mesos states that the project has been superseeded by https://github.com/mesos/elasticsearch.  As such, replace endpoint with the correct link.