### PR TITLE
[MESOS-4370] Retrieve network mode and use that to get that networks IP address.

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -306,8 +306,7 @@ Try<Docker::Container> Docker::Container::create(const string& output)
   Result<JSON::String> networkModeValue =
     json.find<JSON::String>("HostConfig.NetworkMode");
   if (networkModeValue.isNone() || networkModeValue.isError()) {
-    VLOG(1) << "Unable to determine IPAddress at " <<
-               addressLocation + ". Attempting Deprecated API.";
+    VLOG(1) << "Unable to detect networkMode. Using Deprecated API.";
     addressLocation = "NetworkSettings.IPAddress"
   } else {
     addressLocation = "NetworkSettings.Networks." +
@@ -316,16 +315,12 @@ Try<Docker::Container> Docker::Container::create(const string& output)
 
   Result<JSON::String> ipAddressValue =
       json.find<JSON::String>(addressLocation);
-  if (ipAddressValue.isNone() || ipAddressValue.isError()) {
-    Result<JSON::String> ipAddressValue =
-      json.find<JSON::String>("NetworkSettings.IPAddress");
-    if(ipAddressValue.isNone()) {
-      return Error("Unable to find " + addressLocation + " in container");
-    } else if (ipAddressValue.isError()) {
-      return Error(
+  if(ipAddressValue.isNone()) {
+    return Error("Unable to find " + addressLocation + " in container");
+  } else if (ipAddressValue.isError()) {
+    return Error(
         "Error finding " + addressLocation + " in container: " +
         ipAddressValue.error());
-    }
   }
 
   Option<string> ipAddress;


### PR DESCRIPTION
This patch will first query the docker API for the HostConfig.NetworkMode, which is populated with the network name. (Essentially what was passed in --net <name> to the docker run command). This name is then used as a key in NetworkSettings.Networks.<name>.IPAddress to get the IP address that is currently in use by the container.

It appears that even though the docker API has been set up to allow for multiple networks, our testing has indicated that it's still only applying one network to the container (the last one via the --net argument on the run line). I can only speculate that the docker API will change again in the near future, but I can't speculate how, so at least this fixes the problem as it stands right now. This patch is tested against Docker 1.9.1 on Ubuntu 14.04.

Continues #87 