### PR TITLE
Increased status timeout for LinuxFilesystemIsolatorTest.ROOT_Recover…

### DIFF
--- a/src/tests/containerizer/filesystem_isolator_tests.cpp
+++ b/src/tests/containerizer/filesystem_isolator_tests.cpp
@@ -702,7 +702,7 @@ TEST_F(LinuxFilesystemIsolatorTest, ROOT_RecoverOrphanedPersistentVolume)
       {offer.id()},
       {CREATE(persistentVolume), LAUNCH({task})});
 
-  AWAIT_READY(status);
+  AWAIT_READY_FOR(status, Seconds(60));
   EXPECT_EQ(TASK_RUNNING, status.get().state());
 
   // Wait for the ACK to be checkpointed.


### PR DESCRIPTION
…OrphanedPersistentVolume

Fix the following issue when doing make check on RedHat7:

../../src/tests/containerizer/filesystem_isolator_tests.cpp:697: Failure
Failed to wait 15secs for status
../../src/tests/containerizer/filesystem_isolator_tests.cpp:685: Failure
Actual function call count doesn't match EXPECT_CALL(sched, statusUpdate(&driver, _))...
         Expected: to be called at least once
           Actual: never called - unsatisfied and active