### PR TITLE
Avoid 'Permission denied' error with 'sudo cat >'

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,14 +98,14 @@ Following are the instructions for stock CentOS 6.6. If you are using a differen
     # 'Mesos > 0.21.0' requires 'subversion > 1.8' devel package, which is
     # not available in the default repositories.
     # Create a WANdisco SVN repo file to install the correct version:
-    $ sudo cat > /etc/yum.repos.d/wandisco-svn.repo <<EOF
+    $ sudo bash -c 'cat > /etc/yum.repos.d/wandisco-svn.repo <<EOF
     [WANdiscoSVN]
     name=WANdisco SVN Repo 1.8
     enabled=1
     baseurl=http://opensource.wandisco.com/centos/6/svn-1.8/RPMS/$basearch/
     gpgcheck=1
     gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco
-    EOF
+    EOF'
 
     # Install essential development tools.
     $ sudo yum groupinstall -y "Development Tools"
@@ -144,14 +144,14 @@ Following are the instructions for stock CentOS 7.1. If you are using a differen
     # 'Mesos > 0.21.0' requires 'subversion > 1.8' devel package,
     # which is not available in the default repositories.
     # Create a WANdisco SVN repo file to install the correct version:
-    $ sudo cat > /etc/yum.repos.d/wandisco-svn.repo <<EOF
+    $ sudo bash -c 'cat > /etc/yum.repos.d/wandisco-svn.repo <<EOF
     [WANdiscoSVN]
     name=WANdisco SVN Repo 1.9
     enabled=1
     baseurl=http://opensource.wandisco.com/centos/7/svn-1.9/RPMS/$basearch/
     gpgcheck=1
     gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco
-    EOF
+    EOF'
 
     # Parts of Mesos require systemd in order to operate. However, Mesos
     # only supports versions of systemd that contain the 'Delegate' flag.


### PR DESCRIPTION
Not sure if this minor change warrants creation of a JIRA and a review board request. I will do so if required. 

`sudo cat > /etc/yum.repos.d/wandisco-svn.repo << EOF` leads to `bash: /etc/yum.repos.d/wandisco-svn.repo: Permission denied` error. 

`sudo bash -c 'cat > /etc/yum.repos.d/wandisco-svn.repo <<EOF` fixes the problem.