### PR TITLE
Output disk resource source information.

### DIFF
--- a/src/common/resources.cpp
+++ b/src/common/resources.cpp
@@ -1475,6 +1475,19 @@ ostream& operator<<(ostream& stream, const Volume& volume)
   return stream;
 }
 
+ostream& operator<<(ostream& stream, const Resource::DiskInfo::Source& source)
+{
+  switch (source.type()) {
+  case Resource::DiskInfo::Source::MOUNT:
+    stream << ":mount:" << source.mount().root();
+    break;
+  case Resource::DiskInfo::Source::PATH:
+    stream << ":path:" << source.path().root();
+    break;
+  }
+
+  return stream;
+}
 
 ostream& operator<<(ostream& stream, const Resource::DiskInfo& disk)
 {
@@ -1484,6 +1497,10 @@ ostream& operator<<(ostream& stream, const Resource::DiskInfo& disk)
 
   if (disk.has_volume()) {
     stream << ":" << disk.volume();
+  }
+
+  if (disk.has_source()) {
+    stream << ":" << disk.source();
   }
 
   return stream;


### PR DESCRIPTION
This information is obscured when formatted via `stringify`, leading to confusing error messages such as:

```
Task uses more resources
cpus(*):4; mem(*):4096;     ports(*):[31000-31000]; disk(kafka, kafka)[kafka_0:data]:960679
than available
cpus(*):32; mem(*):256819;  ports(*):[31000-32000]; disk(kafka, kafka)[kafka_0:data]:960679;   disk(*):240169;
```

(above was formatted and aligned for clarity)

The validation error here is actually complaining that the disk requested didn't have any source information (and therefore defaulted to a root volume), but the available persistent volume was a mount source.
