### PR TITLE
Add Snap plugin to tools list

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,6 +10,7 @@ layout: documentation
 These tools make it easy to set up and run a Mesos cluster.
 
 * [collectd plugin](https://github.com/rayrod2030/collectd-mesos) to collect Mesos cluster metrics.
+* [Snap plugin](https://github.com/intelsdi-x/snap-plugin-collector-mesos) for collecting Mesos cluster metrics and statistics about running executors.
 * [Deploy scripts](deploy-scripts.md) for launching a Mesos cluster on a set of machines.
 * [Chef cookbook by Everpeace](https://github.com/everpeace/cookbook-mesos) Install Mesos and configure master and agent. This cookbook supports installation from source or the Mesosphere packages.
 * [Chef cookbook by Mdsol](https://github.com/mdsol/mesos_cookbook) Application cookbook for installing the Apache Mesos cluster manager. This cookbook installs Mesos via packages provided by Mesosphere.


### PR DESCRIPTION
Add the newly-released Mesos plugin for Intel's [Snap](https://github.com/intelsdi-x/snap) telemetry framework to the tools documentation.