### PR TITLE
Add Mesos books to documentation page

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -5,6 +5,30 @@ layout: documentation
 
 # Documentation
 
+## Books on Mesos
+
+<div class="row">
+<div class="col-xs-6 col-md-4">
+<a href="https://www.packtpub.com/big-data-and-business-intelligence/apache-mesos-essentials" class="thumbnail">
+<img src="https://www.packtpub.com/sites/default/files/9781783288762.png" alt="Apache Mesos Essentials by Dharmesh Kakadia">
+</a>
+<p class="text-center">Apache Mesos Essentials by Dharmesh Kakadia (Packt, 2015)</p>
+</div>
+<div class="col-xs-6 col-md-4">
+<a href="http://shop.oreilly.com/product/0636920039952.do" class="thumbnail">
+<img src="http://akamaicovers.oreilly.com/images/0636920039952/lrg.jpg" alt="Building Applications on Mesos by David Greenberg">
+</a>
+<p class="text-center">Building Applications on Mesos by David Greenberg (O'Reilly, 2015)</p>
+</div>
+<div class="col-xs-6 col-md-4">
+<a href="https://www.manning.com/books/mesos-in-action" class="thumbnail">
+<img src="https://images.manning.com/255/340/resize/book/d/62f5c9b-0946-4569-ad50-ffdb84876ddc/Ignazio-Mesos-HI.png" alt="Mesos in Action by Roger Ignazio">
+</a>
+<p class="text-center">Mesos in Action by Roger Ignazio (Manning, 2016)
+</div>
+</div>
+
+
 ## Mesos Fundamentals
 
 * [Mesos Architecture](architecture.md) providing an overview of Mesos concepts.


### PR DESCRIPTION
This commit adds the known Mesos books to-date to the Mesos documentation page so that community members can easily find them.

Testing: built the site.

![screen shot 2016-07-28 at 12 40 49 pm](https://cloud.githubusercontent.com/assets/1910193/17226935/c83a235a-54c0-11e6-8c04-fba10ce9465c.png)
