### PR TITLE
[MESOS-6038] Prevent memory leaks

### DIFF
--- a/docs/contributors.yaml
+++ b/docs/contributors.yaml
@@ -1,3 +1,13 @@
+- name: Aaron Wood
+  affiliations:
+    - {organization: Verizon Labs}
+  emails:
+    - aaronjwood@gmail.com
+    - me@aaronjwood.com
+    - aaron.wood@verizon.com
+  jira_user: aaron.wood
+  reviewboard_user: aaron.wood
+
 - name: Adam B
   affiliations:
     - {organization: Mesosphere}

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -344,23 +344,20 @@ public:
       bool watch,
       vector<string>* results)
   {
-    Promise<int>* promise = new Promise<int>();
-
-    Future<int> future = promise->future();
+    Promise<int> promise = Promise<int>();
 
     tuple<Promise<int>*, vector<string>*>* args =
-      new tuple<Promise<int>*, vector<string>*>(promise, results);
+      new tuple<Promise<int>*, vector<string>*>(&promise, results);
 
     int ret =
       zoo_aget_children(zh, path.c_str(), watch, stringsCompletion, args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> set(const string& path, const string& data, int version)

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -291,21 +291,18 @@ public:
 
   Future<int> remove(const string& path, int version)
   {
-    Promise<int>* promise = new Promise<int>();
+    Promise<int> promise = Promise<int>();
 
-    Future<int> future = promise->future();
-
-    tuple<Promise<int>*>* args = new tuple<Promise<int>*>(promise);
+    tuple<Promise<int>*>* args = new tuple<Promise<int>*>(&promise);
 
     int ret = zoo_adelete(zh, path.c_str(), version, voidCompletion, args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> exists(const string& path, bool watch, Stat* stat)

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -163,7 +163,7 @@ public:
 
   Future<int> authenticate(const string& scheme, const string& credentials)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*>* args = new tuple<Promise<int>*>(&promise);
 
@@ -190,7 +190,7 @@ public:
       int flags,
       string* result)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*, string*>* args =
       new tuple<Promise<int>*, string*>(&promise, result);
@@ -291,7 +291,7 @@ public:
 
   Future<int> remove(const string& path, int version)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*>* args = new tuple<Promise<int>*>(&promise);
 
@@ -307,7 +307,7 @@ public:
 
   Future<int> exists(const string& path, bool watch, Stat* stat)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*, Stat*>* args =
       new tuple<Promise<int>*, Stat*>(&promise, stat);
@@ -324,7 +324,7 @@ public:
 
   Future<int> get(const string& path, bool watch, string* result, Stat* stat)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*, string*, Stat*>* args =
       new tuple<Promise<int>*, string*, Stat*>(&promise, result, stat);
@@ -344,7 +344,7 @@ public:
       bool watch,
       vector<string>* results)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*, vector<string>*>* args =
       new tuple<Promise<int>*, vector<string>*>(&promise, results);
@@ -362,7 +362,7 @@ public:
 
   Future<int> set(const string& path, const string& data, int version)
   {
-    Promise<int> promise = Promise<int>();
+    Promise<int> promise;
 
     tuple<Promise<int>*, Stat*>* args =
       new tuple<Promise<int>*, Stat*>(&promise, nullptr);

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -163,11 +163,9 @@ public:
 
   Future<int> authenticate(const string& scheme, const string& credentials)
   {
-    Promise<int>* promise = new Promise<int>();
+    Promise<int> promise = Promise<int>();
 
-    Future<int> future = promise->future();
-
-    tuple<Promise<int>*>* args = new tuple<Promise<int>*>(promise);
+    tuple<Promise<int>*>* args = new tuple<Promise<int>*>(&promise);
 
     int ret = zoo_add_auth(
         zh,
@@ -178,12 +176,11 @@ public:
         args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> create(

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -362,12 +362,10 @@ public:
 
   Future<int> set(const string& path, const string& data, int version)
   {
-    Promise<int>* promise = new Promise<int>();
-
-    Future<int> future = promise->future();
+    Promise<int> promise = Promise<int>();
 
     tuple<Promise<int>*, Stat*>* args =
-      new tuple<Promise<int>*, Stat*>(promise, nullptr);
+      new tuple<Promise<int>*, Stat*>(&promise, nullptr);
 
     int ret = zoo_aset(
         zh,
@@ -379,12 +377,11 @@ public:
         args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
 private:

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -324,22 +324,19 @@ public:
 
   Future<int> get(const string& path, bool watch, string* result, Stat* stat)
   {
-    Promise<int>* promise = new Promise<int>();
-
-    Future<int> future = promise->future();
+    Promise<int> promise = Promise<int>();
 
     tuple<Promise<int>*, string*, Stat*>* args =
-      new tuple<Promise<int>*, string*, Stat*>(promise, result, stat);
+      new tuple<Promise<int>*, string*, Stat*>(&promise, result, stat);
 
     int ret = zoo_aget(zh, path.c_str(), watch, dataCompletion, args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> getChildren(

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -307,22 +307,19 @@ public:
 
   Future<int> exists(const string& path, bool watch, Stat* stat)
   {
-    Promise<int>* promise = new Promise<int>();
-
-    Future<int> future = promise->future();
+    Promise<int> promise = Promise<int>();
 
     tuple<Promise<int>*, Stat*>* args =
-      new tuple<Promise<int>*, Stat*>(promise, stat);
+      new tuple<Promise<int>*, Stat*>(&promise, stat);
 
     int ret = zoo_aexists(zh, path.c_str(), watch, statCompletion, args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> get(const string& path, bool watch, string* result, Stat* stat)

--- a/src/zookeeper/zookeeper.cpp
+++ b/src/zookeeper/zookeeper.cpp
@@ -190,12 +190,10 @@ public:
       int flags,
       string* result)
   {
-    Promise<int>* promise = new Promise<int>();
-
-    Future<int> future = promise->future();
+    Promise<int> promise = Promise<int>();
 
     tuple<Promise<int>*, string*>* args =
-      new tuple<Promise<int>*, string*>(promise, result);
+      new tuple<Promise<int>*, string*>(&promise, result);
 
     int ret = zoo_acreate(
         zh,
@@ -208,12 +206,11 @@ public:
         args);
 
     if (ret != ZOK) {
-      delete promise;
       delete args;
       return ret;
     }
 
-    return future;
+    return promise.future();
   }
 
   Future<int> create(


### PR DESCRIPTION
This should prevent any of the promises that are created in the various `ZookeeperProcess` class methods from leaking memory.

https://reviews.apache.org/r/51068/