### PR TITLE
MESOS-6056 add NOOP Container Logger for mesos.

### DIFF
--- a/docs/contributors.yaml
+++ b/docs/contributors.yaml
@@ -531,3 +531,9 @@
     - w.rouesnel@gmail.com
   jira_user: wrouesnel
   reviewboard_user: wrouesnel
+
+ - name: Ivan Jobs
+  emails:
+    - ivan1377@163.com
+  jira_user: IvanJobs
+  reviewboard_user: IvanJobs

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1949,6 +1949,15 @@ check_PROGRAMS += mesos-tests
 # LDFLAGS to be used for the module libraries.
 MESOS_MODULE_LDFLAGS = -release $(PACKAGE_VERSION) -shared
 
+# Libraray containing the lognoop container logger.
+#
+pkgmodule_LTLIBRARIES += liblognoop_container_logger.la
+liblognoop_container_logger_la_SOURCES =			\
+  slave/container_loggers/lib_lognoop.cpp			\
+  slave/container_loggers/lib_lognoop.hpp
+liblognoop_container_logger_la_CPPFLAGS = $(MESOS_CPPFLAGS)
+liblognoop_container_logger_la_LDFLAGS = $(MESOS_MODULE_LDFLAGS)
+
 # Library containing the logrotate container logger.
 pkgmodule_LTLIBRARIES += liblogrotate_container_logger.la
 liblogrotate_container_logger_la_SOURCES =			\

--- a/src/slave/container_loggers/lib_lognoop.cpp
+++ b/src/slave/container_loggers/lib_lognoop.cpp
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <string>
+
+#include <mesos/mesos.hpp>
+
+#include <mesos/module/container_logger.hpp>
+
+#include <mesos/slave/container_logger.hpp>
+
+#include <process/dispatch.hpp>
+#include <process/future.hpp>
+#include <process/process.hpp>
+#include <process/subprocess.hpp>
+
+#include <stout/try.hpp>
+#include <stout/nothing.hpp>
+
+#include "slave/container_loggers/lib_lognoop.hpp"
+
+
+using namespace mesos;
+using namespace process;
+
+using mesos::slave::ContainerLogger;
+
+namespace mesos {
+namespace internal {
+namespace logger {
+
+using SubprocessInfo = ContainerLogger::SubprocessInfo;
+
+
+class LognoopContainerLoggerProcess :
+  public Process<LognoopContainerLoggerProcess>
+{
+public:
+  LognoopContainerLoggerProcess() {}
+
+  Future<Nothing> recover(
+      const ExecutorInfo& executorInfo,
+      const std::string& sandboxDirectory)
+  {
+    // No state to recover.
+    return Nothing();
+  }
+
+  // just redirect stderr/stdout to /dev/null.
+  Future<SubprocessInfo> prepare(
+      const ExecutorInfo& executorInfo,
+      const std::string& sandboxDirectory)
+  {
+    ContainerLogger::SubprocessInfo info;
+
+    info.out = SubprocessInfo::IO::PATH("/dev/null");
+    info.err = SubprocessInfo::IO::PATH("/dev/null");
+
+    return info;
+  }
+};
+
+
+LognoopContainerLogger::LognoopContainerLogger()
+  : process(new LognoopContainerLoggerProcess())
+{
+  spawn(process.get());
+}
+
+
+LognoopContainerLogger::~LognoopContainerLogger()
+{
+  terminate(process.get());
+  wait(process.get());
+}
+
+
+Try<Nothing> LognoopContainerLogger::initialize()
+{
+  return Nothing();
+}
+
+Future<Nothing> LognoopContainerLogger::recover(
+    const ExecutorInfo& executorInfo,
+    const std::string& sandboxDirectory)
+{
+  return dispatch(
+      process.get(),
+      &LognoopContainerLoggerProcess::recover,
+      executorInfo,
+      sandboxDirectory);
+}
+
+Future<SubprocessInfo> LognoopContainerLogger::prepare(
+    const ExecutorInfo& executorInfo,
+    const std::string& sandboxDirectory)
+{
+  return dispatch(
+      process.get(),
+      &LognoopContainerLoggerProcess::prepare,
+      executorInfo,
+      sandboxDirectory);
+}
+
+} // namespace logger {
+} // namespace internal {
+} // namespace mesos {
+
+
+mesos::modules::Module<ContainerLogger>
+org_apache_mesos_LognoopContainerLogger(
+    MESOS_MODULE_API_VERSION,
+    MESOS_VERSION,
+    "Apache Mesos",
+    "modules@mesos.apache.org",
+    "Lognoop Container Logger module.",
+    nullptr,
+    [](const Parameters& parameters) -> ContainerLogger* {
+      return new mesos::internal::logger::LognoopContainerLogger();
+    });

--- a/src/slave/container_loggers/lib_lognoop.hpp
+++ b/src/slave/container_loggers/lib_lognoop.hpp
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __SLAVE_CONTAINER_LOGGER_LIB_LOGNOOP_HPP__
+#define __SLAVE_CONTAINER_LOGGER_LIB_LOGNOOP_HPP__
+
+#include <mesos/slave/container_logger.hpp>
+
+namespace mesos {
+namespace internal {
+namespace logger {
+
+// Forward declaration.
+class LognoopContainerLoggerProcess;
+
+// The `LognoopContainerLogger` is a container logger
+// that does nothing more than
+// redirecting stderr/stdout to /dev/null.
+class LognoopContainerLogger : public mesos::slave::ContainerLogger
+{
+public:
+  LognoopContainerLogger();
+
+  virtual ~LognoopContainerLogger();
+
+  // This is a noop.  The lognoop container logger has nothing to initialize.
+  virtual Try<Nothing> initialize();
+
+  virtual process::Future<Nothing> recover(
+      const ExecutorInfo& executorInfo,
+      const std::string& sandboxDirectory);
+
+  virtual process::Future<mesos::slave::ContainerLogger::SubprocessInfo>
+  prepare(
+      const ExecutorInfo& executorInfo,
+      const std::string& sandboxDirectory);
+
+protected:
+  process::Owned<LognoopContainerLoggerProcess> process;
+};
+
+} // namespace logger {
+} // namespace internal {
+} // namespace mesos {
+
+#endif // __SLAVE_CONTAINER_LOGGER_LIB_LOGNOOP_HPP__


### PR DESCRIPTION
mesos has two Container Loggers in its source files. 
One is build into mesos-agent: sandbox Container Logger, it just redirects stderr/stdout to sandbox, causing fill disk usage problem.
The other is LogrotateContainerLogger module lib, it's good, we can make sure stdout/stderr in sandbox be in a constant size.
But there is a common need: don't write stdout/stderr into sandbox, pity, we don't have any flags for turning it off. 

This is a come around for this: developing a new module lib for ContainerLogger for doing nothing(redirect stdout/stderr to /dev/null)

yep, that's it. We need a NOOP ContainerLogger,.