### PR TITLE
Frameworks UI shows metrics for used resources plus offers

### DIFF
--- a/src/webui/master/static/frameworks.html
+++ b/src/webui/master/static/frameworks.html
@@ -16,10 +16,10 @@
       <th data-key="role">Role</th>
       <th data-key="principal">Principal</th>
       <th data-key="tasks.length">Active Tasks</th>
-      <th data-key="resources.cpus">CPUs</th>
-      <th data-key="resources.gpus">GPUs</th>
-      <th data-key="resources.mem">Mem</th>
-      <th data-key="resources.disk">Disk</th>
+      <th data-key="used_resources.cpus">CPUs</th>
+      <th data-key="used_resources.gpus">GPUs</th>
+      <th data-key="used_resources.mem">Mem</th>
+      <th data-key="used_resources.disk">Disk</th>
       <th data-key="max_share">Max Share</th>
       <th data-key="registered_time">Registered</th>
       <th data-key="reregistered_time">Re-Registered</th>
@@ -47,10 +47,10 @@
       <td>{{framework.role}}</td>
       <td>{{framework.principal}}</td>
       <td>{{framework.tasks.length}}</td>
-      <td>{{framework.resources.cpus | number}}</td>
-      <td>{{framework.resources.gpus | number}}</td>
-      <td>{{framework.resources.mem * (1024 * 1024) | dataSize}}</td>
-      <td>{{framework.resources.disk * (1024 * 1024) | dataSize}}</td>
+      <td>{{framework.used_resources.cpus | number}}</td>
+      <td>{{framework.used_resources.gpus | number}}</td>
+      <td>{{framework.used_resources.mem * (1024 * 1024) | dataSize}}</td>
+      <td>{{framework.used_resources.disk * (1024 * 1024) | dataSize}}</td>
       <td>{{framework.max_share * 100 | number}}%</td>
       <td>
         <m-timestamp value="{{framework.registered_time * 1000}}"></m-timestamp>
@@ -74,10 +74,10 @@
     <th data-key="role">Role</th>
     <th data-key="principal">Principal</th>
     <th data-key="tasks.length">Active Tasks</th>
-    <th data-key="resources.cpus">CPUs</th>
-    <th data-key="resources.gpus">GPUs</th>
-    <th data-key="resources.mem">Mem</th>
-    <th data-key="resources.disk">Disk</th>
+    <th data-key="used_resources.cpus">CPUs</th>
+    <th data-key="used_resources.gpus">GPUs</th>
+    <th data-key="used_resources.mem">Mem</th>
+    <th data-key="used_resources.disk">Disk</th>
     <th data-key="max_share">Max Share</th>
     <th data-key="registered_time">Registered</th>
     <th data-key="reregistered_time">Re-Registered</th>

--- a/src/webui/master/static/frameworks.html
+++ b/src/webui/master/static/frameworks.html
@@ -105,10 +105,10 @@
     <td>{{framework.role}}</td>
     <td>{{framework.principal}}</td>
     <td>{{framework.tasks.length}}</td>
-    <td>{{framework.resources.cpus | number}}</td>
-    <td>{{framework.resources.gpus | number}}</td>
-    <td>{{framework.resources.mem * (1024 * 1024) | dataSize}}</td>
-    <td>{{framework.resources.disk * (1024 * 1024) | dataSize}}</td>
+    <td>{{framework.used_resources.cpus | number}}</td>
+    <td>{{framework.used_resources.gpus | number}}</td>
+    <td>{{framework.used_resources.mem * (1024 * 1024) | dataSize}}</td>
+    <td>{{framework.used_resources.disk * (1024 * 1024) | dataSize}}</td>
     <td>{{framework.max_share * 100 | number}}%</td>
     <td>
       <m-timestamp value="{{framework.registered_time * 1000}}"></m-timestamp>

--- a/src/webui/master/static/js/controllers.js
+++ b/src/webui/master/static/js/controllers.js
@@ -164,22 +164,22 @@
 
       framework.cpus_share = 0;
       if ($scope.total_cpus > 0) {
-        framework.cpus_share = framework.resources.cpus / $scope.total_cpus;
+        framework.cpus_share = framework.used_resources.cpus / $scope.total_cpus;
       }
 
       framework.gpus_share = 0;
       if ($scope.total_gpus > 0) {
-        framework.gpus_share = framework.resources.gpus / $scope.total_gpus;
+        framework.gpus_share = framework.used_resources.gpus / $scope.total_gpus;
       }
 
       framework.mem_share = 0;
       if ($scope.total_mem > 0) {
-        framework.mem_share = framework.resources.mem / $scope.total_mem;
+        framework.mem_share = framework.used_resources.mem / $scope.total_mem;
       }
 
       framework.disk_share = 0;
       if ($scope.total_disk > 0) {
-        framework.disk_share = framework.resources.disk / $scope.total_disk;
+        framework.disk_share = framework.used_resources.disk / $scope.total_disk;
       }
 
       framework.max_share = Math.max(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MESOS-6098

When a framework is receiving many offers and it is denying them, the frameworks UI will show the metrics fluctuating for mem, cpu, gpu, and disk.
From a mesos perspective, those offers are given to the framework until the framework declines them, so depending on the time the mesos UI gets updated, its has combined all the used resources and offers (that have not been accepted) to the framework and is reflected on the framework UI. If a framework does not implement suppressiveOffers(), it will continue to deny offers from mesos, which leads to the sporadic changes of metrics on the framework UI.
From the operator's perspective, the user would expect to see used resources consumed by the framework. Any offered resources can be viewed instead by Mesos's Offers tab.

cc: @kaysoky 