### PR TITLE
update getting started for Ubuntu 16.04

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,25 @@ Following are the instructions for stock Ubuntu 14.04. If you are using a differ
 
     # Install other Mesos dependencies.
     $ sudo apt-get -y install build-essential python-dev libcurl4-nss-dev libsasl2-dev libsasl2-modules maven libapr1-dev libsvn-dev
+    
+### Ubuntu 16.04
+
+Following are the instructions for stock Ubuntu 16.04. If you are using a different OS, please install the packages accordingly.
+
+    # Update the packages.
+    $ sudo apt-get update
+
+    # Install a few utility tools.
+    $ sudo apt-get install -y tar wget git
+
+    # Install the latest OpenJDK.
+    $ sudo apt-get install -y openjdk-8-jdk
+
+    # Install autotools (Only necessary if building from git repository).
+    $ sudo apt-get install -y autoconf libtool
+
+    # Install other Mesos dependencies.
+    $ sudo apt-get -y install build-essential python-dev libcurl4-nss-dev libsasl2-dev libsasl2-modules maven libapr1-dev libsvn-dev zlib1g-dev
 
 ### Mac OS X Yosemite & El Capitan
 


### PR DESCRIPTION
To follow the getting started instructions to install Mesos on Ubuntu 16.04, it is needed to install one more dependency.