### PR TITLE
Ensure curl is present on Ubuntu

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ Following are the instructions for stock Ubuntu 14.04. If you are using a differ
     $ sudo apt-get update
 
     # Install a few utility tools.
-    $ sudo apt-get install -y tar wget git
+    $ sudo apt-get install -y tar wget git curl
 
     # Install the latest OpenJDK.
     $ sudo apt-get install -y openjdk-7-jdk
@@ -57,7 +57,7 @@ Following are the instructions for stock Ubuntu 16.04. If you are using a differ
     $ sudo apt-get update
 
     # Install a few utility tools.
-    $ sudo apt-get install -y tar wget git
+    $ sudo apt-get install -y tar wget git curl
 
     # Install the latest OpenJDK.
     $ sudo apt-get install -y openjdk-8-jdk


### PR DESCRIPTION
When running on a clean Ubuntu install curl may not be present.  The following error was seen while experimenting with the ubuntu:14.04 Docker container:

```
Received status update TASK_FAILED for task 'test'
  message: 'Failed to launch container: Failed to perform 'curl': ABORT: (../../../3rdparty/libprocess/include/process/posix/subprocess.hpp:214): Failed to os::execvpe on path 'curl': No such file or directory
*** Aborted at 1480435360 (unix time) try "date -d @1480435360" if you are using GNU date ***
PC: @     0x7f1d40711c37 (unknown)
*** SIGABRT (@0x61) received by PID 97 (TID 0x7f1d38ef5700) from PID 97; stack trace: ***
    @     0x7f1d40fca330 (unknown)
    @     0x7f1d40711c37 (unknown)
    @     0x7f1d40715028 (unknown)
    @           0x46e1fc _Abort()
    @           0x46e22a _Abort()
    @     0x7f1d4648d0e1 process::internal::childMain()
    @     0x7f1d46491f7b _ZNSt5_BindIFPFiRKSsPPcS3_RKN7process10Subprocess2IO20InputFileDescriptorsERKNS6_21OutputFileDescriptorsESC_bPiRKSt6vectorINS5_9ChildHookESaISF_EEESsS3_S3_S7_SA_SA_bSD_SH_EE6__callIiJEJLm0ELm1ELm2ELm3ELm4ELm5ELm6ELm7ELm8EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x7f1d46491394 _ZNSt5_BindIFPFiRKSsPPcS3_RKN7process10Subprocess2IO20InputFileDescriptorsERKNS6_21OutputFileDescriptorsESC_bPiRKSt6vectorINS5_9ChildHookESaISF_EEESsS3_S3_S7_SA_SA_bSD_SH_EEclIJEiEET0_DpOT_
    @     0x7f1d464904f0 std::_Function_handler<>::_M_invoke()
    @           0x4780b0 std::function<>::operator()()
    @     0x7f1d4524f325 process::defaultClone()
    @     0x7f1d4648fb3d std::_Function_handler<>::_M_invoke()
    @     0x7f1d4648f3c3 std::function<>::operator()()
    @     0x7f1d4648d93d process::internal::cloneChild()
    @     0x7f1d4648b8c5 process::subprocess()
    @     0x7f1d45b967f1 mesos::uri::curl()
    @     0x7f1d45b96e18 mesos::uri::curl()
    @     0x7f1d45b991b8 mesos::uri::DockerFetcherPluginProcess::fetch()
    @     0x7f1d45ba485a _ZZN7process8dispatchI7NothingN5mesos3uri26DockerFetcherPluginProcessERKNS2_3URIERKSsS5_SsEENS_6FutureIT_EERKNS_3PIDIT0_EEMSE_FSC_T1_T2_ET3_T4_ENKUlPNS_11ProcessBaseEE_clESP_
    @     0x7f1d45baba29 _ZNSt17_Function_handlerIFvPN7process11ProcessBaseEEZNS0_8dispatchI7NothingN5mesos3uri26DockerFetcherPluginProcessERKNS6_3URIERKSsS9_SsEENS0_6FutureIT_EERKNS0_3PIDIT0_EEMSI_FSG_T1_T2_ET3_T4_EUlS2_E_E9_M_invokeERKSt9_Any_dataS2_
    @     0x7f1d46441071 std::function<>::operator()()
    @     0x7f1d46423db1 process::ProcessBase::visit()
    @     0x7f1d4642c1c6 process::DispatchEvent::visit()
    @     0x7f1d4504084c process::ProcessBase::serve()
    @     0x7f1d464200a6 process::ProcessManager::resume()
    @     0x7f1d4641cd31 _ZZN7process14ProcessManager12init_threadsEvENKUt_clEv
    @     0x7f1d4642b96e _ZNSt12_Bind_simpleIFZN7process14ProcessManager12init_threadsEvEUt_vEE9_M_invokeIIEEEvSt12_Index_tupleIIXspT_EEE
    @     0x7f1d4642b8c5 _ZNSt12_Bind_simpleIFZN7process14ProcessManager12init_threadsEvEUt_vEEclEv
    @     0x7f1d4642b85e _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7process14ProcessManager12init_threadsEvEUt_vEEE6_M_runEv
    @     0x7f1d40d67a60 (unknown)
    @     0x7f1d40fc2184 start_thread
    @     0x7f1d407d537d (unknown)
' 
  source: SOURCE_AGENT
  reason: REASON_CONTAINER_LAUNCH_FAILED
```

This is resolved by running 'apt-get install curl' which this PR adds to the getting started instructions.

This PR only adds Curl to the Ubuntu instructions as it is believed to already be present on CentOS:

```shell
$ for dist in ubuntu:14.04 ubuntu:16.04 centos:6.6 centos:7; do echo "$dist: $(docker run $dist curl --version 2>&1 | head -n 1)"; done
ubuntu:14.04: docker: Error response from daemon: oci runtime error: exec: "curl": executable file not found in $PATH.
ubuntu:16.04: docker: Error response from daemon: oci runtime error: exec: "curl": executable file not found in $PATH.
centos:6.6: curl 7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2
centos:7: curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.19.1 Basic ECC zlib/1.2.7 libidn/1.28 libssh2/1.4.3
```