### PR TITLE
Fix python dependencies to avoid installed newer version

### DIFF
--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -26,8 +26,8 @@ config = {
     'packages': [ 'mesos' ],
     'package_dir': { '': 'src' },
     'install_requires': [
-        'mesos.interface',
-        'mesos.native'
+        'mesos.interface == @PACKAGE_VERSION@',
+        'mesos.native == @PACKAGE_VERSION@'
     ],
     'license': 'Apache 2.0',
     'keywords': 'mesos',


### PR DESCRIPTION
Without PACKAGE_VERSION specified, it may install newly python libs from  pypi
if there is one.

Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>