### PR TITLE
Typo: $basearch was not escaped, it should be evaluated by yum

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,7 +187,7 @@ Following are the instructions for stock CentOS 7.1. If you are using a differen
     [WANdiscoSVN]
     name=WANdisco SVN Repo 1.9
     enabled=1
-    baseurl=http://opensource.wandisco.com/centos/7/svn-1.9/RPMS/$basearch/
+    baseurl=http://opensource.wandisco.com/centos/7/svn-1.9/RPMS/\$basearch/
     gpgcheck=1
     gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco
     EOF'


### PR DESCRIPTION
When this code block was run, it would evaluate $basearch in the shell typically giving "", this variable was intended to be used by yum, meaning it should be escaped so as to pass '$basearch' rather than "" (blank) to the yum config file.