### PR TITLE
Fixed a bug in the logging of cni isolator.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
@@ -33,6 +33,7 @@
 #include <stout/os/constants.hpp>
 
 #include "common/protobuf_utils.hpp"
+#include "common/status_utils.hpp"
 
 #include "linux/fs.hpp"
 #include "linux/ns.hpp"
@@ -1994,11 +1995,13 @@ int NetworkCniIsolatorSetup::execute()
       return EXIT_FAILURE;
     }
 
-    if (os::spawn("ifconfig", {"ifconfig", "lo", "up"}) != 0) {
-      cerr << "Failed to bring up the loopback interface in the new "
-           << "network namespace of pid " << flags.pid.get()
-           << ": " << os::strerror(errno) << endl;
-      return EXIT_FAILURE;
+    int spawn = os::spawn("ifconfig", {"ifconfig", "lo", "up"});
+
+    if (spawn != 0) {
+        cerr << "Failed to bring up the loopback interface in the new "
+             << "network namespace of pid " << flags.pid.get()
+             << ": " << (spawn < 0 ? "failed to fork process" : WSTRINGIFY(spawn)) << endl;
+        return EXIT_FAILURE;
     }
   }
 

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
@@ -1999,8 +1999,9 @@ int NetworkCniIsolatorSetup::execute()
 
     if (spawn != 0) {
         cerr << "Failed to bring up the loopback interface in the new "
-             << "network namespace of pid " << flags.pid.get()
-             << ": " << (spawn < 0 ? "Failed to fork process" : WSTRINGIFY(spawn)) << endl;
+             << "network namespace of pid " << flags.pid.get() << ": "
+             << (spawn < 0 ? "Failed to fork or wait process" :
+                     WSTRINGIFY(spawn)) << endl;
         return EXIT_FAILURE;
     }
   }

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.cpp
@@ -2000,7 +2000,7 @@ int NetworkCniIsolatorSetup::execute()
     if (spawn != 0) {
         cerr << "Failed to bring up the loopback interface in the new "
              << "network namespace of pid " << flags.pid.get()
-             << ": " << (spawn < 0 ? "failed to fork process" : WSTRINGIFY(spawn)) << endl;
+             << ": " << (spawn < 0 ? "Failed to fork process" : WSTRINGIFY(spawn)) << endl;
         return EXIT_FAILURE;
     }
   }


### PR DESCRIPTION
the old errno would always be 0, and we can't get the reason that why execute ifconfig failed.

so, we use the return value of spawn for WSTRINGIFYing error in log.

and this fix format issue @haosdent 