### PR TITLE
Corrected quota to define it as minimal and maximal

### DIFF
--- a/docs/quota.md
+++ b/docs/quota.md
@@ -49,7 +49,8 @@ In computer science, a "quota" usually refers to one of the following:
 * A pair of both.
 
 In Mesos, a quota is a **guaranteed** resource allocation that a role may rely
-on; in other words, a minimum share a role is entitled to receive.
+on; and based on the definition above, refers to the pair of both, the
+minimal and maximal share a role is entitled to receive.
 
 
 ## Motivation and Limitations


### PR DESCRIPTION
Based on a discussion with @bmahler, the current documented definition of a quota suggests it guarantees only the minimal guarantee, and that a framework can burst above that minimal.  This is apparently incorrect today, so I've updated the definition accordingly.