### PR TITLE
Fixed reference to Mesos paper in the documentation.

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,4 +34,4 @@ In addition, this resource offer process repeats when tasks finish and new resou
 
 While the thin interface provided by Mesos allows it to scale and allows the frameworks to evolve independently, one question remains: how can the constraints of a framework be satisfied without Mesos knowing about these constraints? For example, how can a framework achieve data locality without Mesos knowing which nodes store the data required by the framework? Mesos answers these questions by simply giving frameworks the ability to **reject** offers. A framework will reject the offers that do not satisfy its constraints and accept the ones that do.  In particular, we have found that a simple policy called delay scheduling, in which frameworks wait for a limited time to acquire nodes storing the input data, yields nearly optimal data locality.
 
-You can also read much more about the Mesos architecture in this [technical paper](http://mesos.berkeley.edu/mesos_tech_report.pdf).
+You can also read much more about the Mesos architecture in this [technical paper](https://www.usenix.org/conference/nsdi11/mesos-platform-fine-grained-resource-sharing-data-center).


### PR DESCRIPTION
The paper is also available at https://people.eecs.berkeley.edu/~alig/papers/mesos.pdf but I noticed it was already included in the site's assets so I just linked that instead.

By the way I wasn't able to generate the website with `./site/mesos-websiste-dev.sh`. I didn't generate the help endpoint beforehand so maybe that's the issue? This is what I'm seeing:
```
$ ./site/mesos-websiste-dev.sh
...
<a bunch of output>
...
Generating example index...
finalizing index lists...
lookup cache used 35887/65536 hits=301982 misses=40583
finished...
rake aborted!
Please make sure Java proto files are generated in ../build/src/java/generated folder.
/mesos/site/Rakefile:77:in `block in <top (required)>'
/usr/local/share/gems/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli/exec.rb:75:in `load'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli/exec.rb:75:in `kernel_load'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli.rb:424:in `exec'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/cli.rb:18:in `start'
/usr/local/share/gems/gems/bundler-1.16.0/exe/bundle:30:in `block in <top (required)>'
/usr/local/share/gems/gems/bundler-1.16.0/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/usr/local/share/gems/gems/bundler-1.16.0/exe/bundle:22:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => default => javadoc
(See full trace by running task with --trace)
Untagged: mesos/website-1509639317-18148:latest
Deleted: sha256:24242decc28e6222d42a24f8f9e8947ce15fcaecb3d94235cd3664b1ade968f4
Deleted: sha256:e7180c9d482f664089b4e441c6df77fda2da2788fa068dd564eab51fa299332f
Deleted: sha256:a75cc639c15951a46d23d5844cee39bc80c6d5bed41523e761cb259857793e26
Deleted: sha256:a5a6c2a58189c9375f80d22982da293ac18214c836cd1596a326838e47a984db
Deleted: sha256:53180dac52d5167d83dd7af08b455b0a5321e01bd660cbcff1646e116cf10a8d
Deleted: sha256:8fc4522bd32a0b5b72f51e2f058a0f19ee0a974ff67903999342da316fb1eeb6
Deleted: sha256:33f70af6654b772ba267987aa23a58d5e5196379bce211be96e8070d2dc19bba
Deleted: sha256:aad2585e5e2bfe7222d6fd38bf8921e7e2ca6ddd63fb66f18ac0dc7ee63b0851
Deleted: sha256:c2441f453bf9135a50005eac91ea64a953bc64a7317b2beb2f9a4e230b7c4303
Deleted: sha256:b6298626e1ee07795ac25ebf0bd0d556792ece844e2b991a086c90fefcb8fd6a
Deleted: sha256:c5930ca7fccd8dcd6bcb12683f6235666c73b91ec04db100469d8dd1fe0680d2
Deleted: sha256:68d1b400d2fd25e919536e1d2f0b4bb5b63538383a19c1faa9a96fb096a41b52
Deleted: sha256:cf2f163eb99cf1ada0a2d75dfc4e98b09a63ffdb20b8649a8089baa6eba91607
```

I also noticed that [some websites](https://www.google.com/search?q="mesos.berkeley.edu/mesos_tech_report.pdf"&oq="mesos.berkeley.edu/mesos_tech_report.pdf") reference the original URL `http://mesos.berkeley.edu/mesos_tech_report.pdf`, so maybe it could also make sense to get that working again?