### PR TITLE
Add curl examples to operator-http-api

### DIFF
--- a/docs/operator-http-api.md
+++ b/docs/operator-http-api.md
@@ -28,23 +28,19 @@ Below are the example calls to master that result in synchronous responses from 
 This call retrieves the health status of master.
 
 ```
-GET_HEALTH HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_HEALTH"
 }
+EOF
+```
 
-
-GET_HEALTH HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -53,7 +49,6 @@ Content-Type: application/json
     "healthy": true
   }
 }
-
 ```
 
 ### GET_FLAGS
@@ -61,23 +56,19 @@ Content-Type: application/json
 This call retrieves the master's overall flag configuration.
 
 ```
-GET_FLAGS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @- << EOF
 {
   "type": "GET_FLAGS"
 }
+EOF
+```
 
-
-GET_FLAGS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -235,7 +226,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_VERSION
@@ -243,23 +233,19 @@ Content-Type: application/json
 This call retrieves the master's version information.
 
 ```
-GET_VERSION HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @- << EOF
 {
   "type": "GET_VERSION"
 }
+EOF
+```
 
-
-GET_VERSION HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -273,7 +259,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### GET_METRICS
@@ -284,28 +269,24 @@ API will take to respond. If the timeout is exceeded, some metrics may not be
 included in the response.
 
 ```
-GET_METRICS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @- << EOF
 {
   "type": "GET_METRICS",
-  "get_metrics": {
-    "timeout": {
-      "nanoseconds": 5000000000
+    "get_metrics": {
+      "timeout": {
+        "nanoseconds": 5000000000
+      }
     }
-  }
 }
+EOF
+```
 
-
-GET_METRICS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -743,7 +724,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_LOGGING_LEVEL
@@ -751,23 +731,19 @@ Content-Type: application/json
 This call retrieves the master's logging level.
 
 ```
-GET_LOGGING_LEVEL HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_LOGGING_LEVEL"
 }
+EOF
+```
 
-
-GET_LOGGING_LEVEL HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -776,7 +752,6 @@ Content-Type: application/json
     "level": 0
   }
 }
-
 ```
 
 ### SET_LOGGING_LEVEL
@@ -787,14 +762,11 @@ verbose logging which means nothing will be output unless the verbosity
 level is set (by default it's 0, libprocess uses levels 1, 2, and 3).
 
 ```
-SET_LOGGING_LEVEL HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "SET_LOGGING_LEVEL",
   "set_logging_level": {
@@ -804,12 +776,11 @@ Accept: application/json
     "level": 1
   }
 }
+EOF
+```
 
-
-SET_LOGGING_LEVEL HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### LIST_FILES
@@ -817,26 +788,22 @@ HTTP/1.1 202 Accepted
 This call retrieves the file listing for a directory in master.
 
 ```
-LIST_FILES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "LIST_FILES",
   "list_files": {
     "path": "one/"
   }
 }
+EOF
+```
 
-
-LIST_FILES HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -879,7 +846,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### READ_FILE
@@ -889,14 +855,11 @@ file to be read, the offset to start reading, and the maximum number of
 bytes to read.
 
 ```
-READ_FILE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "READ_FILE",
   "read_file": {
@@ -905,12 +868,11 @@ Accept: application/json
     "path": "myname"
   }
 }
+EOF
+```
 
-
-READ_FILE HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -920,7 +882,6 @@ Content-Type: application/json
     "size": 4
   }
 }
-
 ```
 
 ### GET_STATE
@@ -928,23 +889,19 @@ Content-Type: application/json
 This call retrieves the overall cluster state.
 
 ```
-GET_STATE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_STATE"
 }
+EOF
+```
 
-
-GET_STATE HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1211,7 +1168,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### GET_AGENTS
@@ -1219,23 +1175,19 @@ Content-Type: application/json
 This call retrieves information about all the agents known to the master.
 
 ```
-GET_AGENTS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_AGENTS"
 }
+EOF
+```
 
-
-GET_AGENTS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {{
@@ -1338,7 +1290,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_FRAMEWORKS
@@ -1346,23 +1297,19 @@ Content-Type: application/json
 This call retrieves information about all the frameworks known to the master.
 
 ```
-GET_FRAMEWORKS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_FRAMEWORKS"
 }
+EOF
+```
 
-
-GET_FRAMEWORKS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1394,7 +1341,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_EXECUTORS
@@ -1402,23 +1348,19 @@ Content-Type: application/json
 Queries about all the executors known to the master.
 
 ```
-GET_EXECUTORS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_EXECUTORS"
 }
+EOF
+```
 
-
-GET_EXECUTORS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1445,7 +1387,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_TASKS
@@ -1453,23 +1394,19 @@ Content-Type: application/json
 Query about all the tasks known to the master.
 
 ```
-GET_TASKS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_TASKS"
 }
+EOF
+```
 
-
-GET_TASKS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1564,7 +1501,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_ROLES
@@ -1572,23 +1508,19 @@ Content-Type: application/json
 Query the information about roles.
 
 ```
-GET_ROLES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_ROLES"
 }
+EOF
+```
 
-
-GET_ROLES HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1650,7 +1582,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_WEIGHTS
@@ -1658,23 +1589,19 @@ Content-Type: application/json
 This call retrieves the information about role weights.
 
 ```
-GET_WEIGHTS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_WEIGHTS"
 }
+EOF
+```
 
-
-GET_WEIGHTS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1688,7 +1615,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### UPDATE_WEIGHTS
@@ -1697,14 +1623,11 @@ This call updates weights for specific role. This call takes `weight_infos`
 which needs `role` value and `weight` value.
 
 ```
-UPDATE_WEIGHTS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "UPDATE_WEIGHTS",
   "update_weights": {
@@ -1716,12 +1639,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-UPDATE_WEIGHTS HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### GET_MASTER
@@ -1729,23 +1651,19 @@ HTTP/1.1 202 Accepted
 This call retrieves information about the master.
 
 ```
-GET_MASTER HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_MASTER"
 }
+EOF
+```
 
-
-GET_MASTER HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -1766,7 +1684,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### RESERVE_RESOURCES
@@ -1775,14 +1692,11 @@ This call reserve resources dynamically on a specific agent. This call takes
 `agent_id` and `resources` details like the following.
 
 ```
-RESERVE_RESOURCES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "RESERVE_RESOURCES",
   "reserve_resources": {
@@ -1815,12 +1729,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-RESERVE_RESOURCES HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### UNRESERVE_RESOURCES
@@ -1829,14 +1742,11 @@ This call unreserve resources dynamically on a specific agent. This call takes
 `agent_id` and `resources` details like the following.
 
 ```
-UNRESERVE_RESOURCES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "UNRESERVE_RESOURCES",
   "unreserve_resources": {
@@ -1869,12 +1779,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-UNRESERVE_RESOURCES HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### CREATE_VOLUMES
@@ -1886,14 +1795,11 @@ at the agent might fail. This call takes `agent_id` and `volumes` details like
 the following.
 
 ```
-CREATE_VOLUMES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "CREATE_VOLUMES",
   "create_volumes": {
@@ -1922,12 +1828,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-CREATE_VOLUMES HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### DESTROY_VOLUMES
@@ -1936,14 +1841,11 @@ This call destroys persistent volumes. The request is forwarded asynchronously t
 Mesos agent where the reserved resources are located.
 
 ```
-DESTROY_VOLUMES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "DESTROY_VOLUMES",
   "destroy_volumes": {
@@ -1972,12 +1874,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-DESTROY_VOLUMES HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### GET_MAINTENANCE_STATUS
@@ -1985,23 +1886,19 @@ HTTP/1.1 202 Accepted
 This call retrieves the cluster's maintenance status.
 
 ```
-GET_MAINTENANCE_STATUS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_MAINTENANCE_STATUS"
 }
+EOF
+```
 
-
-GET_MAINTENANCE_STATUS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -2023,7 +1920,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### GET_MAINTENANCE_SCHEDULE
@@ -2031,23 +1927,19 @@ Content-Type: application/json
 This call retrieves the cluster's maintenance schedule.
 
 ```
-GET_MAINTENANCE_SCHEDULE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_MAINTENANCE_SCHEDULE"
 }
+EOF
+```
 
-
-GET_MAINTENANCE_SCHEDULE HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 Content-Type: application/json
 
 {
@@ -2074,7 +1966,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### UPDATE_MAINTENANCE_SCHEDULE
@@ -2082,14 +1973,11 @@ Content-Type: application/json
 This call updates the cluster's maintenance schedule.
 
 ```
-UPDATE_MAINTENANCE_SCHEDULE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "UPDATE_MAINTENANCE_SCHEDULE",
   "update_maintenance_schedule": {
@@ -2114,12 +2002,11 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-
-UPDATE_MAINTENANCE_SCHEDULE HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### START_MAINTENANCE
@@ -2128,14 +2015,11 @@ This call starts the maintenance of the cluster, this would bring a set of machi
 down.
 
 ```
-START_MAINTENANCE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "START_MAINTENANCE",
   "start_maintenance": {
@@ -2147,12 +2031,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-START_MAINTENANCE HTTP Response:
-
-HTTP/1.1 202 Accepted
-
+```
+HTTP/1.1 202 Accepted 
 ```
 
 ### STOP_MAINTENANCE
@@ -2161,14 +2044,11 @@ Stops the maintenance of the cluster, this would bring a set of machines
 back up.
 
 ```
-STOP_MAINTENANCE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "STOP_MAINTENANCE",
   "stop_maintenance": {
@@ -2180,12 +2060,11 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-
-STOP_MAINTENANCE HTTP Response:
-
+```
 HTTP/1.1 202 Accepted
-
 ```
 
 ### GET_QUOTA
@@ -2193,23 +2072,19 @@ HTTP/1.1 202 Accepted
 This call retrieves the cluster's configured quotas.
 
 ```
-GET_QUOTA HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_QUOTA"
 }
+EOF
+```
 
-
-GET_QUOTA HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 Content-Type: application/json
 
 {
@@ -2243,7 +2118,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### SET_QUOTA
@@ -2251,14 +2125,11 @@ Content-Type: application/json
 This call sets the quota for resources to be used by a particular role.
 
 ```
-SET_QUOTA HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "SET_QUOTA",
   "set_quota": {
@@ -2286,12 +2157,11 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-
-SET_QUOTA HTTP Response:
-
-HTTP/1.1 202 Accepted
-
+```
+HTTP/1.1 202 Accepted 
 ```
 
 ### REMOVE_QUOTA
@@ -2299,26 +2169,22 @@ HTTP/1.1 202 Accepted
 This call removes the quota for a particular role.
 
 ```
-REMOVE_QUOTA HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "REMOVE_QUOTA",
   "remove_quota": {
     "role": "role1"
   }
 }
+EOF
+```
 
-
-REMOVE_QUOTA HTTP Response:
-
-HTTP/1.1 202 Accepted
-
+```
+HTTP/1.1 202 Accepted 
 ```
 
 ### MARK_AGENT_GONE
@@ -2334,14 +2200,11 @@ the master. The agent would be shutdown when it tries to re-register with the
 master when the partition heals. This call is idempotent.
 
 ```
-MARK_AGENT_GONE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "MARK_AGENT_GONE",
   "mark_agent_gone": {
@@ -2350,9 +2213,10 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-MARK_AGENT_GONE HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```
 
@@ -2361,21 +2225,19 @@ HTTP/1.1 200 OK
 Currently, the only call that results in a streaming response is the `SUBSCRIBE` call sent to the master API.
 
 ```
-SUBSCRIBE Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: masterhost:5050
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<masterhost>:5050/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "SUBSCRIBE"
 }
+EOF
+```
 
-SUBSCRIBE Response Event (JSON):
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 Transfer-Encoding: chunked
 
@@ -2679,23 +2541,19 @@ Request and Response are similar to GET_HEALTH call to master.
 This call retrieves the agent's flag configuration.
 
 ```
-GET_FLAGS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_FLAGS"
 }
+EOF
+```
 
-
-GET_FLAGS HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 Content-Type: application/json
 
 {
@@ -2957,7 +2815,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_VERSION
@@ -2990,23 +2847,19 @@ This call retrieves full state of the agent i.e. information about the tasks,
 frameworks and executors running in the cluster.
 
 ```
-GET_STATE HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_STATE"
 }
+EOF
+```
 
-
-GET_STATE HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -3161,7 +3014,6 @@ Content-Type: application/json
     }
   }
 }
-
 ```
 
 ### GET_CONTAINERS
@@ -3175,14 +3027,11 @@ API will return:
 * `show_standalone`: Whether to show standalone containers [default: false].
 
 ```
-GET_CONTAINERS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_CONTAINERS",
   "get_containers": {
@@ -3190,12 +3039,11 @@ Accept: application/json
     "show_standalone": false
   }
 }
+EOF
+```
 
-
-GET_CONTAINERS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -3232,7 +3080,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_FRAMEWORKS
@@ -3240,23 +3087,19 @@ Content-Type: application/json
 This call retrieves information about all the frameworks known to the agent.
 
 ```
-GET_FRAMEWORKS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_FRAMEWORKS"
 }
+EOF
+```
 
-
-GET_FRAMEWORKS HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 Content-Type: application/json
 
 {
@@ -3280,7 +3123,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_EXECUTORS
@@ -3288,23 +3130,20 @@ Content-Type: application/json
 This call retrieves information about all the executors known to the agent.
 
 ```
-GET_EXECUTORS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_EXECUTORS"
 }
+EOF
+```
 
 
-GET_EXECUTORS HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 Content-Type: application/json
 
 {
@@ -3352,7 +3191,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### GET_TASKS
@@ -3360,23 +3198,19 @@ Content-Type: application/json
 This call retrieves information about all the tasks known to the agent.
 
 ```
-GET_TASKS HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "GET_TASKS"
 }
+EOF
+```
 
-
-GET_TASKS HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -3469,7 +3303,6 @@ Content-Type: application/json
     ]
   }
 }
-
 ```
 
 ### LAUNCH_NESTED_CONTAINER
@@ -3479,14 +3312,11 @@ including the executor itself, its tasks, or the operator can use this
 API to launch a nested container.
 
 ```
-LAUNCH_NESTED_CONTAINER HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "LAUNCH_NESTED_CONTAINER",
   "launch_nested_container": {
@@ -3514,11 +3344,11 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-LAUNCH_NESTED_CONTAINER HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 ```
 
 ### WAIT_NESTED_CONTAINER
@@ -3528,14 +3358,11 @@ authorized entity, including the executor itself, its tasks, or the
 operator can use this API to wait on a nested container.
 
 ```
-WAIT_NESTED_CONTAINER HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "WAIT_NESTED_CONTAINER",
   "wait_nested_container": {
@@ -3547,11 +3374,11 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-WAIT_NESTED_CONTAINER HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/json
 
 {
@@ -3560,7 +3387,6 @@ Content-Type: application/json
     "exit_status": 0
   }
 }
-
 ```
 
 ### KILL_NESTED_CONTAINER
@@ -3570,14 +3396,11 @@ authorized entity, including the executor itself, its tasks, or the
 operator can use this API to kill a nested container.
 
 ```
-KILL_NESTED_CONTAINER HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "KILL_NESTED_CONTAINER",
   "kill_nested_container": {
@@ -3589,11 +3412,11 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-KILL_NESTED_CONTAINER HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 ```
 
 ### LAUNCH_NESTED_CONTAINER_SESSION
@@ -3604,15 +3427,12 @@ STDERR of the nested container is streamed back to the client so long
 as the connection is active.
 
 ```
-LAUNCH_NESTED_CONTAINER_SESSION HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/recordio
-Message-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/recordio" \
+  -H "Message-Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "LAUNCH_NESTED_CONTAINER_SESSION",
   "launch_nested_container_session": {
@@ -3640,11 +3460,11 @@ Message-Accept: application/json
     }
   }
 }
+EOF
+```
 
-LAUNCH_NESTED_CONTAINER_SESSION HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/recordio
 Message-Content-Type: application/json
 
@@ -3671,7 +3491,6 @@ Message-Content-Type: application/json
   }
 }
 ...
-
 ```
 
 ### ATTACH_CONTAINER_INPUT
@@ -3694,10 +3513,12 @@ CONTROL message sends a heartbeat to keep the connection alive. We may
 add more CONTROL messages in the future.
 
 ```
-ATTACH_CONTAINER_INPUT HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Message-Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 Host: agenthost:5051
 Content-Type: application/recordio
 Message-Content-Type: application/json
@@ -3745,11 +3566,11 @@ Accept: application/json
   }
 }
 ...
+EOF
+```
 
-ATTACH_CONTAINER_INPUT HTTP Response (JSON):
-
-HTTP/1.1 200 OK
-
+```
+HTTP/1.1 200 OK 
 ```
 
 ### ATTACH_CONTAINER_OUTPUT
@@ -3764,15 +3585,12 @@ ATTACH_CONTAINER_OUTPUT calls can be active for a given container at
 once.
 
 ```
-ATTACH_CONTAINER_OUTPUT HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/recordio
-Message-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/recordio" \
+  -H "Message-Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "ATTACH_CONTAINER_OUTPUT",
   "attach_container_output": {
@@ -3781,11 +3599,11 @@ Message-Accept: application/json
     }
   }
 }
+EOF
+```
 
-ATTACH_CONTAINER_OUTPUT HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
-
 Content-Type: application/recordio
 Message-Content-Type: application/json
 
@@ -3812,7 +3630,6 @@ Message-Content-Type: application/json
   }
 }
 ...
-
 ```
 
 ### REMOVE_NESTED_CONTAINER
@@ -3824,14 +3641,11 @@ container has not been destroyed. Any authorized entity, including the
 executor itself, its tasks, or the operator can use this API call.
 
 ```
-REMOVE_NESTED_CONTAINER HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "REMOVE_NESTED_CONTAINER",
   "remove_nested_container": {
@@ -3843,9 +3657,10 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-REMOVE_NESTED_CONTAINER HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```
 
@@ -3855,14 +3670,11 @@ This call launches a Local Resource Provider on the agent with the specified
 `ResourceProviderInfo`.
 
 ```
-ADD_RESOURCE_PROVIDER_CONFIG HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "ADD_RESOURCE_PROVIDER_CONFIG",
   "add_resource_provider_config": {
@@ -3906,9 +3718,10 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-ADD_RESOURCE_PROVIDER_CONFIG HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```
 
@@ -3928,14 +3741,11 @@ This call updates a Local Resource Provider on the agent with the specified
 `ResourceProviderInfo`.
 
 ```
-UPDATE_RESOURCE_PROVIDER_CONFIG HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "UPDATE_RESOURCE_PROVIDER_CONFIG",
   "update_resource_provider_config": {
@@ -3979,9 +3789,10 @@ Accept: application/json
     }
   }
 }
+EOF
+```
 
-UPDATE_RESOURCE_PROVIDER_CONFIG HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```
 
@@ -4016,14 +3827,11 @@ provider as gone, in which case the local resource provider will not be allowed
 to be re-added.  Marking a local resource provider as gone is not yet supported.
 
 ```
-REMOVE_RESOURCE_PROVIDER_CONFIG HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "REMOVE_RESOURCE_PROVIDER_CONFIG",
   "remove_resource_provider_config": {
@@ -4031,9 +3839,10 @@ Accept: application/json
     "name": "test_slrp"
   }
 }
+EOF
+```
 
-REMOVE_RESOURCE_PROVIDER_CONFIG HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```
 
@@ -4055,14 +3864,11 @@ or newer. An optional list of excluded images from GC can be speficied via
 `prune_images.excluded_images` field.
 
 ```
-PRUNE_IMAGES HTTP Request (JSON):
-
-POST /api/v1  HTTP/1.1
-
-Host: agenthost:5051
-Content-Type: application/json
-Accept: application/json
-
+$ curl -i \
+  -X POST http://<agenthost>:5051/api/v1 \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d  @- << EOF
 {
   "type": "PRUNE_IMAGES",
   "prune_images": {
@@ -4071,8 +3877,9 @@ Accept: application/json
     ]
   }
 }
+EOF
+```
 
-PRUNE_IMAGES HTTP Response (JSON):
-
+```
 HTTP/1.1 200 OK
 ```


### PR DESCRIPTION
When reading this document, many people will want to test out the
requests against their own environment. Providing curl examples will
help assist with this task.