### PR TITLE
Add new MesosCons, fix 404s on to presentations.md

### DIFF
--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -6,13 +6,43 @@ layout: documentation
 # Video and Slides of Mesos Presentations
 _(Listed in date descending order)_
 
-## MesosCon Europe 2015
- [Video playlist](https://www.youtube.com/watch?v=K-x7yOy8Ymk&list=PLGeM09tlguZS6MhlSZDbf-gANWdKgje0I)
- [Slides](http://events.linuxfoundation.org/events/archive/2015/mesoscon-europe/program/slides)
+## MesosCon Europe 2017
+[Video playlist](https://www.youtube.com/playlist?list=PLbzoR-pLrL6rSBqPhTh_lmeMmxn6AOSjf)
 
-## MesosCon Seattle 2015
- [Video playlist](https://www.youtube.com/watch?v=aV6pdWveN7s&list=PLVjgeV_avap2arug3vIz8c6l72rvh9poV)
- [Slides](http://events.linuxfoundation.org/events/archive/2015/mesoscon/program/slides)
+[Slides](http://events17.linuxfoundation.org/events/archive/2017/mesoscon-europe/program/slides)
+
+## MesosCon North America 2017
+[Video playlist](https://www.youtube.com/playlist?list=PLbzoR-pLrL6qAEnkhkh5tGI6oX_xXD3X4)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2017/mesoscon-north-america/program/slides)
+
+## MesosCon Asia 2017
+[Video playlist](https://www.youtube.com/playlist?list=PLbzoR-pLrL6rZfzCL_b-W9yxcJQhZ0RUg)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2017/mesoscon-asia/program/slides)
+
+## MesosCon Asia 2016
+[Video playlist](https://www.youtube.com/playlist?list=PLbzoR-pLrL6pLSHrXSg7IYgzSlkOh132K)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2016/mesoscon-asia/program/slides)
+
+## MesosCon Europe 2016
+[Slides](http://events17.linuxfoundation.org/events/archive/2016/mesoscon-europe/program/slides)
+
+## MesosCon North America 2016
+[Video playlist](https://www.youtube.com/playlist?list=PLGeM09tlguZQVL7ZsfNMffX9h1rGNVqnC)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2016/mesoscon-north-america/program/slides)
+
+## MesosCon Europe 2015
+[Video playlist](https://www.youtube.com/watch?v=K-x7yOy8Ymk&list=PLGeM09tlguZS6MhlSZDbf-gANWdKgje0I)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2015/mesoscon-europe/program/slides)
+
+## MesosCon North America 2015
+[Video playlist](https://www.youtube.com/watch?v=aV6pdWveN7s&list=PLVjgeV_avap2arug3vIz8c6l72rvh9poV)
+
+[Slides](http://events17.linuxfoundation.org/events/archive/2015/mesoscon-north-america/program/slides)
 
 ## Building and Deploying Applications to Apache Mesos
 ([Slides](https://www.slideshare.net/charmalloc/buildingdeployingapplicationsmesos))


### PR DESCRIPTION
Fixed 404s caused by Linux Foundation URL structure changes.
Added new MesosCon slides and Playlists.
Linked to playlist URLs that don't autoplay when you visit them.