### PR TITLE
Updating reservation.md

### DIFF
--- a/docs/reservation.md
+++ b/docs/reservation.md
@@ -623,18 +623,18 @@ We send an HTTP POST request to the master's
               "name": "cpus",
               "type": "SCALAR",
               "scalar": { "value": 8 },
-              "role": "ads",
               "reservation": {
-                "principal": <operator_principal>
+                "principal": <operator_principal>,
+                "role": "ads"
               }
             },
             {
               "name": "mem",
               "type": "SCALAR",
               "scalar": { "value": 4096 },
-              "role": "ads",
               "reservation": {
-                "principal": <operator_principal>
+                "principal": <operator_principal>,
+                "role": "ads"
               }
             }
           ]' \
@@ -671,18 +671,18 @@ We can send an HTTP POST request to the master's
               "name": "cpus",
               "type": "SCALAR",
               "scalar": { "value": 8 },
-              "role": "ads",
               "reservation": {
-                "principal": <reserver_principal>
+                "principal": <reserver_principal>,
+                "role": "ads"
               }
             },
             {
               "name": "mem",
               "type": "SCALAR",
               "scalar": { "value": 4096 },
-              "role": "ads",
               "reservation": {
-                "principal": <reserver_principal>
+                "principal": <reserver_principal>,
+                "role": "ads"
               }
             }
           ]' \


### PR DESCRIPTION
When using the Operator API, I came to this document to get a better understand of resource reservations. It wasn't clear to me that the reservation or reservations keys were a requirement given that the principal configuration is optional. What I do know is that the role can be set in the resource object or the reservation object. I think we might as well instruct users to set the role in the reservation object so it is more clear that it is required to successfully POST the request. After a quick google search, I noted that another user ran into the same issue and posted about it in IRC. 