### PR TITLE
Allow nested containers in pods to have separate namespaces(Ref: MESOS-8534).

### DIFF
--- a/src/master/validation.cpp
+++ b/src/master/validation.cpp
@@ -1498,6 +1498,15 @@ Option<Error> validateTask(
   }
 
   if (task.has_container()) {
+    if (task.has_health_check() &&
+        task.container().network_infos().size() > 0) {
+        if (task.health_check().type() ==
+            HealthCheck::HTTP || HealthCheck::TCP) {
+          return Error("HTTP and TCP health checks are not supported for "
+                       "nested containers not joining parent's network");
+        }
+    }
+
     if (task.container().type() == ContainerInfo::DOCKER) {
       return Error("Docker ContainerInfo is not supported on the task");
     }

--- a/src/master/validation.cpp
+++ b/src/master/validation.cpp
@@ -1498,10 +1498,6 @@ Option<Error> validateTask(
   }
 
   if (task.has_container()) {
-    if (task.container().network_infos().size() > 0) {
-      return Error("NetworkInfos must not be set on the task");
-    }
-
     if (task.container().type() == ContainerInfo::DOCKER) {
       return Error("Docker ContainerInfo is not supported on the task");
     }

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
@@ -95,7 +95,8 @@ private:
           const Option<std::string>& _hostname = None())
       : containerNetworks (_containerNetworks),
         rootfs(_rootfs),
-        hostname(_hostname) {}
+        hostname(_hostname),
+        needsSeparateNs(false) {}
 
     // CNI network information keyed by network name.
     //
@@ -110,6 +111,7 @@ private:
     const Option<std::string> rootfs;
 
     const Option<std::string> hostname;
+    bool needsSeparateNs = false;
   };
 
   // Reads each CNI config present in `configDir`, validates if the

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
@@ -92,11 +92,12 @@ private:
   {
     Info (const hashmap<std::string, ContainerNetwork>& _containerNetworks,
           const Option<std::string>& _rootfs = None(),
-          const Option<std::string>& _hostname = None())
+          const Option<std::string>& _hostname = None(),
+          bool _joinsParentsNetwork = false)
       : containerNetworks (_containerNetworks),
         rootfs(_rootfs),
         hostname(_hostname),
-        joinsParentsNetwork(false) {}
+        joinsParentsNetwork(_joinsParentsNetwork) {}
 
     // CNI network information keyed by network name.
     //
@@ -111,7 +112,7 @@ private:
     const Option<std::string> rootfs;
 
     const Option<std::string> hostname;
-    bool joinsParentsNetwork = false;
+    const bool joinsParentsNetwork;
   };
 
   // Reads each CNI config present in `configDir`, validates if the
@@ -142,7 +143,7 @@ private:
   process::Future<Nothing> _isolate(
       const ContainerID& containerId,
       pid_t pid,
-      const list<process::Future<Nothing>>& attaches);
+      const std::list<process::Future<Nothing>>& attaches);
 
   process::Future<Nothing> __isolate(
       const NetworkCniIsolatorSetup& setup);
@@ -204,7 +205,7 @@ private:
   hashmap<std::string, std::string> networkConfigs;
 
   // DNS informations of CNI networks keyed by CNI network name.
-  hashmap<string, ContainerDNSInfo::MesosInfo> cniDNSMap;
+  hashmap<std::string, ContainerDNSInfo::MesosInfo> cniDNSMap;
 
   // Default DNS information for all CNI networks.
   const Option<ContainerDNSInfo::MesosInfo> defaultCniDNS;

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
@@ -96,7 +96,7 @@ private:
       : containerNetworks (_containerNetworks),
         rootfs(_rootfs),
         hostname(_hostname),
-        joinParentsNetwork(true) {}
+        joinsParentsNetwork(false) {}
 
     // CNI network information keyed by network name.
     //
@@ -111,7 +111,7 @@ private:
     const Option<std::string> rootfs;
 
     const Option<std::string> hostname;
-    bool joinParentsNetwork = true;
+    bool joinsParentsNetwork = false;
   };
 
   // Reads each CNI config present in `configDir`, validates if the

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
@@ -95,8 +95,7 @@ private:
           const Option<std::string>& _hostname = None())
       : containerNetworks (_containerNetworks),
         rootfs(_rootfs),
-        hostname(_hostname),
-        needsSeparateNs(false) {}
+        hostname(_hostname) {}
 
     // CNI network information keyed by network name.
     //
@@ -111,6 +110,7 @@ private:
     const Option<std::string> rootfs;
 
     const Option<std::string> hostname;
+
     bool needsSeparateNs = false;
   };
 

--- a/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/cni.hpp
@@ -95,7 +95,8 @@ private:
           const Option<std::string>& _hostname = None())
       : containerNetworks (_containerNetworks),
         rootfs(_rootfs),
-        hostname(_hostname) {}
+        hostname(_hostname),
+        joinParentsNetwork(true) {}
 
     // CNI network information keyed by network name.
     //
@@ -110,8 +111,7 @@ private:
     const Option<std::string> rootfs;
 
     const Option<std::string> hostname;
-
-    bool needsSeparateNs = false;
+    bool joinParentsNetwork = true;
   };
 
   // Reads each CNI config present in `configDir`, validates if the

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
@@ -14,10 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stout/path.hpp>
-#include <stout/fs.hpp>
-
 #include "slave/containerizer/mesos/isolators/network/cni/paths.hpp"
+
+#include <mesos/type_utils.hpp>
+
+#include <stout/fs.hpp>
+#include <stout/path.hpp>
+#include <stout/stringify.hpp>
 
 using std::string;
 using std::list;
@@ -28,13 +31,17 @@ namespace slave {
 namespace cni {
 namespace paths {
 
-string getContainerDir(const string& rootDir, const string& containerId)
+string getContainerDir(
+    const string& rootDir,
+    const ContainerID& containerId)
 {
-  return path::join(rootDir, containerId);
+  return path::join(rootDir, stringify(containerId));
 }
 
 
-string getNamespacePath(const string& rootDir, const string& containerId)
+string getNamespacePath(
+    const string& rootDir,
+    const ContainerID& containerId)
 {
   return path::join(getContainerDir(rootDir, containerId), "ns");
 }
@@ -42,7 +49,7 @@ string getNamespacePath(const string& rootDir, const string& containerId)
 
 string getNetworkDir(
     const string& rootDir,
-    const string& containerId,
+    const ContainerID& containerId,
     const string& networkName)
 {
   return path::join(getContainerDir(rootDir, containerId), networkName);
@@ -51,7 +58,7 @@ string getNetworkDir(
 
 Try<list<string>> getNetworkNames(
     const string& rootDir,
-    const string& containerId)
+    const ContainerID& containerId)
 {
   const string& networkInfoDir = getContainerDir(rootDir, containerId);
 
@@ -77,7 +84,7 @@ Try<list<string>> getNetworkNames(
 
 string getNetworkConfigPath(
     const string& rootDir,
-    const string& containerId,
+    const ContainerID& containerId,
     const string& networkName)
 {
   return path::join(
@@ -88,7 +95,7 @@ string getNetworkConfigPath(
 
 string getInterfaceDir(
     const string& rootDir,
-    const string& containerId,
+    const ContainerID& containerId,
     const string& networkName,
     const string& ifName)
 {
@@ -98,7 +105,7 @@ string getInterfaceDir(
 
 Try<list<string>> getInterfaces(
     const string& rootDir,
-    const string& containerId,
+    const ContainerID& containerId,
     const string& networkName)
 {
   const string& networkDir = getNetworkDir(rootDir, containerId, networkName);
@@ -125,7 +132,7 @@ Try<list<string>> getInterfaces(
 
 string getNetworkInfoPath(
     const string& rootDir,
-    const string& containerId,
+    const ContainerID& containerId,
     const string& networkName,
     const string& ifName)
 {

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
@@ -33,6 +33,12 @@ string getContainerDir(const string& rootDir, const string& containerId)
   return path::join(rootDir, containerId);
 }
 
+string getJoinParentsNetworkPath(const string& rootDir,
+    const string& containerId) {
+  return path::join(getContainerDir(rootDir, containerId),
+       "joinParentsNetworkConfig");
+}
+
 
 string getNamespacePath(const string& rootDir, const string& containerId)
 {

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.cpp
@@ -33,12 +33,6 @@ string getContainerDir(const string& rootDir, const string& containerId)
   return path::join(rootDir, containerId);
 }
 
-string getJoinParentsNetworkPath(const string& rootDir,
-    const string& containerId) {
-  return path::join(getContainerDir(rootDir, containerId),
-       "joinParentsNetworkConfig");
-}
-
 
 string getNamespacePath(const string& rootDir, const string& containerId)
 {

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
@@ -17,8 +17,12 @@
 #ifndef __ISOLATOR_CNI_PATHS_HPP__
 #define __ISOLATOR_CNI_PATHS_HPP__
 
-using std::string;
-using std::list;
+#include <list>
+#include <string>
+
+#include <mesos/mesos.hpp>
+
+#include <stout/try.hpp>
 
 namespace mesos {
 namespace internal {
@@ -44,47 +48,51 @@ namespace paths {
 constexpr char ROOT_DIR[] = "/var/run/mesos/isolators/network/cni";
 
 
-string getContainerDir(const string& rootDir, const string& containerId);
+std::string getContainerDir(
+    const std::string& rootDir,
+    const ContainerID& containerId);
 
 
-string getNamespacePath(const string& rootDir, const string& containerId);
+std::string getNamespacePath(
+    const std::string& rootDir,
+    const ContainerID& containerId);
 
 
-string getNetworkDir(
-    const string& rootDir,
-    const string& containerId,
-    const string& networkName);
+std::string getNetworkDir(
+    const std::string& rootDir,
+    const ContainerID& containerId,
+    const std::string& networkName);
 
 
-Try<list<string>> getNetworkNames(
-    const string& rootDir,
-    const string& containerId);
+Try<std::list<std::string>> getNetworkNames(
+    const std::string& rootDir,
+    const ContainerID& containerId);
 
 
-string getNetworkConfigPath(
-    const string& rootDir,
-    const string& containerId,
-    const string& networkName);
+std::string getNetworkConfigPath(
+    const std::string& rootDir,
+    const ContainerID& containerId,
+    const std::string& networkName);
 
 
-string getInterfaceDir(
-    const string& rootDir,
-    const string& containerId,
-    const string& networkName,
-    const string& ifName);
+std::string getInterfaceDir(
+    const std::string& rootDir,
+    const ContainerID& containerId,
+    const std::string& networkName,
+    const std::string& ifName);
 
 
-Try<list<string>> getInterfaces(
-    const string& rootDir,
-    const string& containerId,
-    const string& networkName);
+Try<std::list<std::string>> getInterfaces(
+    const std::string& rootDir,
+    const ContainerID& containerId,
+    const std::string& networkName);
 
 
-string getNetworkInfoPath(
-    const string& rootDir,
-    const string& containerId,
-    const string& networkName,
-    const string& ifName);
+std::string getNetworkInfoPath(
+    const std::string& rootDir,
+    const ContainerID& containerId,
+    const std::string& networkName,
+    const std::string& ifName);
 
 } // namespace paths {
 } // namespace cni {

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
@@ -67,11 +67,6 @@ string getNetworkConfigPath(
     const string& networkName);
 
 
-string getJoinParentsNetworkPath(
-    const string& rootDir,
-    const string& containerId);
-
-
 string getInterfaceDir(
     const string& rootDir,
     const string& containerId,

--- a/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/cni/paths.hpp
@@ -67,6 +67,11 @@ string getNetworkConfigPath(
     const string& networkName);
 
 
+string getJoinParentsNetworkPath(
+    const string& rootDir,
+    const string& containerId);
+
+
 string getInterfaceDir(
     const string& rootDir,
     const string& containerId,

--- a/src/tests/containerizer/cni_isolator_tests.cpp
+++ b/src/tests/containerizer/cni_isolator_tests.cpp
@@ -1581,6 +1581,164 @@ TEST_P(DefaultExecutorCniTest, ROOT_VerifyContainerIP)
 }
 
 
+class NestedContainerCniTest
+  : public CniIsolatorTest,
+    public WithParamInterface<bool>
+{
+protected:
+  slave::Flags CreateSlaveFlags()
+  {
+    slave::Flags flags = CniIsolatorTest::CreateSlaveFlags();
+
+    flags.network_cni_plugins_dir = cniPluginDir;
+    flags.network_cni_config_dir = cniConfigDir;
+    flags.isolation = "docker/runtime,filesystem/linux,network/cni";
+    flags.image_providers = "docker";
+    flags.launcher = "linux";
+
+    return flags;
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    JoinParentsNetworkParam,
+    NestedContainerCniTest,
+    ::testing::Values(
+        true,
+        false));
+
+TEST_P(NestedContainerCniTest, VerifyContainerHostname)
+{
+  const string parentContainerHostname = "parent_container";
+  const string nestedContainerHostname = "nested_container";
+  const string hostPathPrefix = "/tmp";
+  const string containerPathPrefix = "/host_tmp";
+  const bool joinParentsNetwork = GetParam();
+
+  // Remove all the files that this test is expected to create
+  os::rm(path::join(hostPathPrefix, parentContainerHostname));
+  os::rm(path::join(hostPathPrefix, nestedContainerHostname));
+
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+
+  slave::Flags flags = CreateSlaveFlags();
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Try<Owned<cluster::Slave>> slave = StartSlave(detector.get(), flags);
+  ASSERT_SOME(slave);
+
+  auto scheduler = std::make_shared<v1::MockHTTPScheduler>();
+
+  EXPECT_CALL(*scheduler, connected(_))
+    .WillOnce(v1::scheduler::SendSubscribe(v1::DEFAULT_FRAMEWORK_INFO));
+
+  Future<v1::scheduler::Event::Subscribed> subscribed;
+  EXPECT_CALL(*scheduler, subscribed(_, _))
+    .WillOnce(FutureArg<1>(&subscribed));
+
+  Future<v1::scheduler::Event::Offers> offers;
+  EXPECT_CALL(*scheduler, offers(_, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return());
+
+  EXPECT_CALL(*scheduler, heartbeat(_))
+    .WillRepeatedly(Return()); // Ignore heartbeats.
+
+  v1::scheduler::TestMesos mesos(
+      master.get()->pid, ContentType::PROTOBUF, scheduler);
+
+  AWAIT_READY(subscribed);
+  v1::FrameworkID frameworkId(subscribed->framework_id());
+
+  v1::ExecutorInfo executorInfo = v1::createExecutorInfo(
+      "test_default_executor",
+      None(),
+      "cpus:0.1;mem:32;disk:32",
+      v1::ExecutorInfo::DEFAULT);
+
+  // Update `executorInfo` with the subscribed `frameworkId`.
+  executorInfo.mutable_framework_id()->CopyFrom(frameworkId);
+
+  mesos::v1::ContainerInfo *executorContainer =
+    executorInfo.mutable_container();
+  executorContainer->set_type(mesos::v1::ContainerInfo::MESOS);
+  executorContainer->add_network_infos()->set_name("__MESOS_TEST__");
+  executorContainer->set_hostname(parentContainerHostname);
+
+  AWAIT_READY(offers);
+  ASSERT_FALSE(offers->offers().empty());
+
+  const v1::Offer& offer = offers->offers(0);
+  const v1::AgentID& agentId = offer.agent_id();
+
+  v1::TaskInfo taskInfo = v1::createTask(
+      agentId,
+      v1::Resources::parse("cpus:0.1;mem:32;disk:32").get(),
+      "/bin/touch /host_tmp/$(hostname)");
+
+  mesos::v1::Image image;
+  image.set_type(mesos::v1::Image::DOCKER);
+  image.mutable_docker()->set_name("alpine");
+
+  mesos::v1::ContainerInfo* nestedContainer = taskInfo.mutable_container();
+  nestedContainer->set_type(mesos::v1::ContainerInfo::MESOS);
+  nestedContainer->mutable_mesos()->mutable_image()->CopyFrom(image);
+  if (!joinParentsNetwork) {
+    nestedContainer->add_network_infos()->set_name("__MESOS_TEST__");
+    nestedContainer->set_hostname(nestedContainerHostname);
+  }
+
+  mesos::v1::Volume* containerVolume = nestedContainer->add_volumes();
+  containerVolume->set_mode(mesos::v1::Volume::RW);
+  containerVolume->set_container_path(containerPathPrefix);
+  containerVolume->set_host_path(hostPathPrefix);
+
+  Future<v1::scheduler::Event::Update> updateStarting;
+  Future<v1::scheduler::Event::Update> updateRunning;
+  Future<v1::scheduler::Event::Update> updateFinished;
+  EXPECT_CALL(*scheduler, update(_, _))
+    .WillOnce(DoAll(FutureArg<1>(&updateStarting),
+                    v1::scheduler::SendAcknowledge(
+                        frameworkId,
+                        offer.agent_id())))
+    .WillOnce(DoAll(FutureArg<1>(&updateRunning),
+                    v1::scheduler::SendAcknowledge(
+                        frameworkId,
+                        offer.agent_id())))
+    .WillOnce(FutureArg<1>(&updateFinished));
+
+  v1::Offer::Operation launchGroup = v1::LAUNCH_GROUP(
+      executorInfo,
+      v1::createTaskGroupInfo({taskInfo}));
+
+  mesos.send(v1::createCallAccept(frameworkId, offer, {launchGroup}));
+
+  AWAIT_READY(updateStarting);
+  ASSERT_EQ(v1::TASK_STARTING, updateStarting->status().state());
+  EXPECT_EQ(taskInfo.task_id(), updateStarting->status().task_id());
+
+  AWAIT_READY(updateRunning);
+  ASSERT_EQ(v1::TASK_RUNNING, updateRunning->status().state());
+  EXPECT_EQ(taskInfo.task_id(), updateRunning->status().task_id());
+
+  AWAIT_READY(updateFinished);
+  ASSERT_EQ(v1::TASK_FINISHED, updateFinished->status().state());
+  EXPECT_EQ(taskInfo.task_id(), updateFinished->status().task_id());
+
+  if (joinParentsNetwork) {
+    EXPECT_TRUE(os::exists(path::join("/tmp", parentContainerHostname)));
+  } else {
+    EXPECT_TRUE(os::exists(path::join("/tmp", nestedContainerHostname)));
+  }
+
+  // Remove all the files that this test creates
+  os::rm(path::join(hostPathPrefix, parentContainerHostname));
+  os::rm(path::join(hostPathPrefix, nestedContainerHostname));
+}
+
+
+
 class CniIsolatorPortMapperTest : public CniIsolatorTest
 {
 public:

--- a/src/tests/containerizer/cni_isolator_tests.cpp
+++ b/src/tests/containerizer/cni_isolator_tests.cpp
@@ -376,23 +376,23 @@ TEST_F(CniIsolatorTest, ROOT_VerifyCheckpointedInfo)
 
   // Check if the CNI related information is checkpointed successfully.
   const string containerDir =
-    paths::getContainerDir(paths::ROOT_DIR, containerId.value());
+    paths::getContainerDir(paths::ROOT_DIR, containerId);
 
   EXPECT_TRUE(os::exists(containerDir));
   EXPECT_TRUE(os::exists(paths::getNetworkDir(
-      paths::ROOT_DIR, containerId.value(), "__MESOS_TEST__")));
+      paths::ROOT_DIR, containerId, "__MESOS_TEST__")));
 
   EXPECT_TRUE(os::exists(paths::getNetworkConfigPath(
-      paths::ROOT_DIR, containerId.value(), "__MESOS_TEST__")));
+      paths::ROOT_DIR, containerId, "__MESOS_TEST__")));
 
   EXPECT_TRUE(os::exists(paths::getInterfaceDir(
-      paths::ROOT_DIR, containerId.value(), "__MESOS_TEST__", "eth0")));
+      paths::ROOT_DIR, containerId, "__MESOS_TEST__", "eth0")));
 
   EXPECT_TRUE(os::exists(paths::getNetworkInfoPath(
-      paths::ROOT_DIR, containerId.value(), "__MESOS_TEST__", "eth0")));
+      paths::ROOT_DIR, containerId, "__MESOS_TEST__", "eth0")));
 
   EXPECT_TRUE(os::exists(paths::getNamespacePath(
-      paths::ROOT_DIR, containerId.value())));
+      paths::ROOT_DIR, containerId)));
 
   EXPECT_TRUE(os::exists(path::join(containerDir, "hostname")));
   EXPECT_TRUE(os::exists(path::join(containerDir, "hosts")));

--- a/src/tests/master_validation_tests.cpp
+++ b/src/tests/master_validation_tests.cpp
@@ -3433,11 +3433,15 @@ TEST_F(TaskGroupValidationTest, TaskUsesDockerContainerInfo)
 
 
 // Ensures that a task in a task group that has `NetworkInfo`
-// set is rejected during `TaskGroupInfo` validation.
-TEST_F(TaskGroupValidationTest, TaskUsesNetworkInfo)
+// set does not have HTTP health checks during `TaskGroupInfo` validation.
+TEST_F(TaskGroupValidationTest,
+       NestedTaskWithNetworkInfosDoesNotHaveHTTPHealthChecks)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
+
+  FrameworkInfo frameworkInfo = DEFAULT_FRAMEWORK_INFO;
+  frameworkInfo.mutable_id()->set_value("Test_Framework");
 
   Owned<MasterDetector> detector = master.get()->createDetector();
   Try<Owned<cluster::Slave>> slave = StartSlave(detector.get());
@@ -3445,7 +3449,7 @@ TEST_F(TaskGroupValidationTest, TaskUsesNetworkInfo)
 
   MockScheduler sched;
   MesosSchedulerDriver driver(
-      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+      &sched, frameworkInfo, master.get()->pid, DEFAULT_CREDENTIAL);
 
   EXPECT_CALL(sched, registered(&driver, _, _));
 
@@ -3460,37 +3464,126 @@ TEST_F(TaskGroupValidationTest, TaskUsesNetworkInfo)
   ASSERT_FALSE(offers->empty());
   Offer offer = offers.get()[0];
 
-  Resources resources = Resources::parse("cpus:1;mem:512;disk:32").get();
+  Resources resources = Resources::parse("cpus:0.5;mem:300;disk:100").get();
 
   ExecutorInfo executor(DEFAULT_EXECUTOR_INFO);
   executor.set_type(ExecutorInfo::CUSTOM);
   executor.mutable_resources()->CopyFrom(resources);
+  executor.mutable_framework_id()->CopyFrom(frameworkInfo.id());
 
-  // Create an invalid task that has NetworkInfos set.
-  TaskInfo task1;
-  task1.set_name("1");
-  task1.mutable_task_id()->set_value("1");
-  task1.mutable_slave_id()->MergeFrom(offer.slave_id());
-  task1.mutable_resources()->MergeFrom(resources);
-  task1.mutable_container()->set_type(ContainerInfo::MESOS);
-  task1.mutable_container()->add_network_infos();
+  TaskInfo task;
+  task.set_name("1");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offer.slave_id());
+  task.mutable_resources()->MergeFrom(resources);
+  task.mutable_container()->set_type(ContainerInfo::MESOS);
+  task.mutable_container()->add_network_infos();
 
-  // Create a valid task.
-  TaskInfo task2;
-  task2.set_name("2");
-  task2.mutable_task_id()->set_value("2");
-  task2.mutable_slave_id()->MergeFrom(offer.slave_id());
-  task2.mutable_resources()->MergeFrom(resources);
+  // Add a HTTP health check to this task.
+  HealthCheck healthCheck;
+  healthCheck.set_type(HealthCheck::HTTP);
+  healthCheck.mutable_http()->set_port(80);
+  healthCheck.set_delay_seconds(0);
+  healthCheck.set_interval_seconds(0);
+  healthCheck.set_grace_period_seconds(15);
+
+  task.mutable_health_check()->CopyFrom(healthCheck);
 
   TaskGroupInfo taskGroup;
-  taskGroup.add_tasks()->CopyFrom(task1);
-  taskGroup.add_tasks()->CopyFrom(task2);
+  taskGroup.add_tasks()->CopyFrom(task);
 
-  Future<TaskStatus> task1Status;
-  Future<TaskStatus> task2Status;
+  Future<TaskStatus> taskStatus;
   EXPECT_CALL(sched, statusUpdate(&driver, _))
-    .WillOnce(FutureArg<1>(&task1Status))
-    .WillOnce(FutureArg<1>(&task2Status));
+    .WillOnce(FutureArg<1>(&taskStatus));
+
+  Offer::Operation operation;
+  operation.set_type(Offer::Operation::LAUNCH_GROUP);
+
+  Offer::Operation::LaunchGroup* launchGroup =
+    operation.mutable_launch_group();
+
+  launchGroup->mutable_executor()->CopyFrom(executor);
+  launchGroup->mutable_task_group()->CopyFrom(taskGroup);
+
+  driver.acceptOffers({offer.id()}, {operation});
+  const string expected =
+    "Task '1' is invalid: HTTP and TCP health checks are not supported "
+    "for nested containers not joining parent's network";
+
+  AWAIT_READY(taskStatus);
+  EXPECT_EQ(task.task_id(), taskStatus->task_id());
+  EXPECT_EQ(TASK_ERROR, taskStatus->state());
+  EXPECT_EQ(TaskStatus::REASON_TASK_GROUP_INVALID, taskStatus->reason());
+  EXPECT_EQ(expected, taskStatus->message());
+
+  driver.stop();
+  driver.join();
+}
+
+
+// Ensures that a task in a task group that has `NetworkInfo`
+// set does not have TCP health checks during `TaskGroupInfo` validation.
+TEST_F(TaskGroupValidationTest,
+       NestedTaskWithNetworkInfosDoesNotHaveTCPHealthChecks)
+{
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+
+  FrameworkInfo frameworkInfo = DEFAULT_FRAMEWORK_INFO;
+  frameworkInfo.mutable_id()->set_value("Test_Framework");
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Try<Owned<cluster::Slave>> slave = StartSlave(detector.get());
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, frameworkInfo, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_FALSE(offers->empty());
+  Offer offer = offers.get()[0];
+
+  Resources resources = Resources::parse("cpus:0.5;mem:300;disk:100").get();
+
+  ExecutorInfo executor(DEFAULT_EXECUTOR_INFO);
+  executor.set_type(ExecutorInfo::DEFAULT);
+  executor.mutable_resources()->CopyFrom(resources);
+  executor.mutable_framework_id()->CopyFrom(frameworkInfo.id());
+
+  TaskInfo task;
+  task.set_name("1");
+  task.mutable_task_id()->set_value("1");
+  task.mutable_slave_id()->MergeFrom(offer.slave_id());
+  task.mutable_resources()->MergeFrom(resources);
+  task.mutable_container()->set_type(ContainerInfo::MESOS);
+  task.mutable_container()->add_network_infos();
+
+  // Add a TCP health check to this task.
+  HealthCheck healthCheck;
+  healthCheck.set_type(HealthCheck::TCP);
+  healthCheck.mutable_tcp()->set_port(30000);
+  healthCheck.set_delay_seconds(0);
+  healthCheck.set_interval_seconds(0);
+  healthCheck.set_grace_period_seconds(15);
+
+  task.mutable_health_check()->CopyFrom(healthCheck);
+
+  TaskGroupInfo taskGroup;
+  taskGroup.add_tasks()->CopyFrom(task);
+
+  Future<TaskStatus> taskStatus;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&taskStatus));
 
   Offer::Operation operation;
   operation.set_type(Offer::Operation::LAUNCH_GROUP);
@@ -3503,17 +3596,15 @@ TEST_F(TaskGroupValidationTest, TaskUsesNetworkInfo)
 
   driver.acceptOffers({offer.id()}, {operation});
 
-  AWAIT_READY(task1Status);
-  EXPECT_EQ(task1.task_id(), task1Status->task_id());
-  EXPECT_EQ(TASK_ERROR, task1Status->state());
-  EXPECT_EQ(TaskStatus::REASON_TASK_GROUP_INVALID, task1Status->reason());
-  EXPECT_EQ("Task '1' is invalid: NetworkInfos must not be set on the task",
-            task1Status->message());
+  const string expected =
+    "Task '1' is invalid: HTTP and TCP health checks are not supported "
+    "for nested containers not joining parent's network";
 
-  AWAIT_READY(task2Status);
-  EXPECT_EQ(task2.task_id(), task2Status->task_id());
-  EXPECT_EQ(TASK_ERROR, task2Status->state());
-  EXPECT_EQ(TaskStatus::REASON_TASK_GROUP_INVALID, task2Status->reason());
+  AWAIT_READY(taskStatus);
+  EXPECT_EQ(task.task_id(), taskStatus->task_id());
+  EXPECT_EQ(TASK_ERROR, taskStatus->state());
+  EXPECT_EQ(TaskStatus::REASON_TASK_GROUP_INVALID, taskStatus->reason());
+  EXPECT_EQ(expected, taskStatus->message());
 
   driver.stop();
   driver.join();


### PR DESCRIPTION
This change allows nested containers to have separate network and mount namespaces. It also retains the existing functionality, where a nested container can attach to parent's network and mount namespace.

I have not fixed/added tests for this. First, I want to make sure that this is the right approach. If this change looks good to the reviewers, I will fix/add unit tests.

After this change is shipped, the docs also need to be updated.