### PR TITLE
Replace a dead link.

### DIFF
--- a/docs/cni.md
+++ b/docs/cni.md
@@ -484,8 +484,8 @@ provide tenant isolation, security groups, and external reachability
 constraints.
 
 For information on setting up and using Calico-CNI, see [Calico's
-guide on adding Calico-CNI to
-Mesos](https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/ManualInstallCalicoCNI.md).
+guide on integerating with
+Mesos](https://docs.projectcalico.org/v2.6/getting-started/mesos/).
 
 #### <a name="a-cilium-network">A Cilium network</a>
 


### PR DESCRIPTION
The docs we used to link to were removed in https://github.com/projectcalico/calicoctl/commit/9ce8e39a8bb0e973589a582557246718795570fe without further comments. Link to something close instead.