### PR TITLE
 Fix wrong example of executor message.

### DIFF
--- a/docs/executor-http-api.md
+++ b/docs/executor-http-api.md
@@ -206,7 +206,9 @@ Accept: application/json
     "value": "9aaa9d0d-e00d-444f-bfbd-23dd197939a0-0000"
   },
   "type": "MESSAGE",
-  "data": "t+Wonz5fRFKMzCnEptlv5A=="
+  "message": {
+    "data": "t+Wonz5fRFKMzCnEptlv5A=="
+  }
 }
 
 MESSAGE Response:


### PR DESCRIPTION
The example of executor message in executor-http-api.md is wrong. This patch fixes this.