### PR TITLE
Remove accent from first name of clems4ever contributor.

### DIFF
--- a/docs/contributors.yaml
+++ b/docs/contributors.yaml
@@ -216,7 +216,7 @@
   jira_user: chhsia0
   reviewboard_user: chhsia0
 
-- name: Clément Michaud
+- name: Clement Michaud
   affiliations:
     - {organization: Criteo}
   emails:


### PR DESCRIPTION
Review bot fails to apply reviews (with ./support/apply-review.py script) because of the accent in my first name.