### PR TITLE
mesos.scheduler and mesos.executor seem to cause errors, changing to mesos.native

### DIFF
--- a/src/examples/python/test_executor.py
+++ b/src/examples/python/test_executor.py
@@ -22,7 +22,7 @@ import time
 
 import mesos.interface
 from mesos.interface import mesos_pb2
-from mesos.executor import MesosExecutorDriver
+from mesos.native import MesosExecutorDriver
 
 class MyExecutor(mesos.interface.Executor):
     def launchTask(self, driver, task):

--- a/src/examples/python/test_framework.py
+++ b/src/examples/python/test_framework.py
@@ -22,7 +22,7 @@ import time
 
 import mesos.interface
 from mesos.interface import mesos_pb2
-from mesos.scheduler import MesosSchedulerDriver
+from mesos.native import MesosSchedulerDriver
 
 TOTAL_TASKS = 5
 


### PR DESCRIPTION
A fix for the python framework and executor example.