### PR TITLE
Expose new metrics for memory usage in the container.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1670,6 +1670,12 @@ message ResourceStatistics {
   // Total memory + swap usage. This is set if swap is enabled.
   optional uint64 mem_total_memsw_bytes = 37;
 
+  // Current kernel memory allocation
+  optional uint64 mem_kmem_usage_bytes = 52;
+
+  // Current TCP buf memory allocation
+  optional uint64 mem_kmem_tcp_usage_bytes = 53;
+
   // Hard memory limit for a container.
   optional uint64 mem_limit_bytes = 6;
 

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1662,6 +1662,12 @@ message ResourceStatistics {
   // Total memory + swap usage. This is set if swap is enabled.
   optional uint64 mem_total_memsw_bytes = 37;
 
+  // Current kernel memory allocation
+  optional uint64 mem_kmem_usage_bytes = 52;
+
+  // Current TCP buf memory allocation
+  optional uint64 mem_kmem_tcp_usage_bytes = 53;
+
   // Hard memory limit for a container.
   optional uint64 mem_limit_bytes = 6;
 

--- a/src/linux/cgroups.cpp
+++ b/src/linux/cgroups.cpp
@@ -2574,6 +2574,58 @@ Try<Bytes> max_usage_in_bytes(const string& hierarchy, const string& cgroup)
 }
 
 
+Result<Bytes> kmem_usage_in_bytes(const string& hierarchy, const string& cgroup)
+{
+  Try<bool> exists = cgroups::exists(
+      hierarchy, cgroup, "memory.kmem.usage_in_bytes");
+
+  if (exists.isError()) {
+    return Error(
+        "Could not check for existence of 'memory.kmem.usage_in_bytes': " +
+        exists.error());
+  }
+
+  if (!exists.get()) {
+    return None();
+  }
+
+  Try<string> read = cgroups::read(
+      hierarchy, cgroup, "memory.kmem.usage_in_bytes");
+
+  if (read.isError()) {
+    return Error(read.error());
+  }
+
+  return Bytes::parse(strings::trim(read.get()) + "B");
+}
+
+
+Result<Bytes> kmem_tcp_usage_in_bytes(const string& hierarchy, const string& cgroup)
+{
+  Try<bool> exists = cgroups::exists(
+      hierarchy, cgroup, "memory.kmem.tcp.usage_in_bytes");
+
+  if (exists.isError()) {
+    return Error(
+      "Could not check for existence of 'memory.kmem.tcp.usage_in_bytes': " +
+      exists.error());
+  }
+
+  if (!exists.get()) {
+    return None();
+  }
+
+  Try<string> read = cgroups::read(
+      hierarchy, cgroup, "memory.kmem.tcp.usage_in_bytes");
+
+  if (read.isError()) {
+    return Error(read.error());
+  }
+
+  return Bytes::parse(strings::trim(read.get()) + "B");
+}
+
+
 namespace oom {
 
 Future<Nothing> listen(const string& hierarchy, const string& cgroup)

--- a/src/linux/cgroups.hpp
+++ b/src/linux/cgroups.hpp
@@ -787,6 +787,20 @@ Try<Bytes> max_usage_in_bytes(
     const std::string& cgroup);
 
 
+// Returns the memory usage from memory.kmem.usage_in_bytes. Returns
+// none if memory.kmem.usage_in_bytes is not supported.
+Result<Bytes> kmem_usage_in_bytes(
+    const std::string& hierarchy,
+    const std::string& cgroup);
+
+
+// Returns the memory usage from memory.kmem.tcp.usage_in_bytes. Returns
+// none if memory.kmem.tcp.usage_in_bytes is not supported.
+Result<Bytes> kmem_tcp_usage_in_bytes(
+    const std::string& hierarchy,
+    const std::string& cgroup);
+
+
 // Out-of-memory (OOM) controls.
 namespace oom {
 

--- a/src/slave/containerizer/mesos/isolators/cgroups/subsystems/memory.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups/subsystems/memory.cpp
@@ -324,6 +324,22 @@ Future<ResourceStatistics> MemorySubsystemProcess::usage(
 
   result.set_mem_total_bytes(usage->bytes());
 
+  Result<Bytes> kmem_usage = cgroups::memory::kmem_usage_in_bytes(hierarchy, cgroup);
+
+  if (kmem_usage.isError()) {
+    return Failure("Failed to parse 'memory.kmem.usage_in_bytes': " + kmem_usage.error());
+  } else if (kmem_usage.isSome()) {
+    result.set_mem_kmem_usage_bytes(kmem_usage.get().bytes());
+  }
+
+  Result<Bytes> kmem_tcp_usage = cgroups::memory::kmem_tcp_usage_in_bytes(hierarchy, cgroup);
+
+  if (kmem_tcp_usage.isError()) {
+    return Failure("Failed to parse 'memory.kmem.tcp.usage_in_bytes': " + kmem_tcp_usage.error());
+  } else if (kmem_usage.isSome()) {
+    result.set_mem_kmem_tcp_usage_bytes(kmem_tcp_usage.get().bytes());
+  }
+
   if (flags.cgroups_limit_swap) {
     Try<Bytes> usage = cgroups::memory::memsw_usage_in_bytes(hierarchy, cgroup);
 


### PR DESCRIPTION
The metric "mem_kmem_usage_bytes" is the total kernel memory usage by
processes in the cgroup in bytes.

The metric "mem_kmem_tcp_usage_bytes" is the total memory usage for TCP
buffers in bytes.