### PR TITLE
Fixed the iptables deadlock in CNI port mapper plugin.

### DIFF
--- a/src/common/values.hpp
+++ b/src/common/values.hpp
@@ -19,6 +19,7 @@
 
 #include <limits>
 #include <type_traits>
+#include <vector>
 
 #include <mesos/mesos.hpp>
 
@@ -51,6 +52,30 @@ Try<IntervalSet<T>> rangesToIntervalSet(const Value::Ranges& ranges)
   }
 
   return set;
+}
+
+
+template <typename T>
+Try<std::vector<T>> rangesToVector(const Value::Ranges& ranges)
+{
+  std::vector<T> result;
+
+  static_assert(
+      std::is_integral<T>::value,
+      "vector<T> must use an integral type");
+
+  foreach (const Value::Range& range, ranges.range()) {
+    if (range.begin() < std::numeric_limits<T>::min() ||
+        range.end() > std::numeric_limits<T>::max()) {
+      return Error("Range is out of bounds");
+    }
+
+    for (T value = range.begin(); value <= range.end(); value++) {
+      result.push_back(value);
+    }
+  }
+
+  return result;
 }
 
 


### PR DESCRIPTION
Patch 1: 

It is possible that the port mapping cleanup command will cause iptables
to deadlock if there are a lot of entires in the iptables, because the
`sed` won't process the next line while executing 'iptables -w -t nat -D
...'. But the executing of 'iptables -w -t nat -D ...' might get stuck
if the first command 'iptables -w -t nat -S %s' didn't finish (because
the xtables lock is not released). The first command might not finish if
it has a lot of output, filling the pipe that `sed` hasn't had a chance
to process yet. See more details in MESOS-9127.

This patch fixed the issue by writing the commands to a file and then
executing them.

Patch 2:

Updated port mapper CNI test.

This patch updated the port mapper CNI test to launch multiple
containers concurrently. This would allow us to catch the scenarios
where multiple iptables commands are executed concurrently.

This test fails if the fix for MESOS-9125 is not included.