### PR TITLE
Added Python 3.6 and pip to Docker ARM image.

### DIFF
--- a/support/mesos-build/ubuntu-16.04-arm.dockerfile
+++ b/support/mesos-build/ubuntu-16.04-arm.dockerfile
@@ -39,7 +39,20 @@ RUN apt-get update && \
       python-dev \
       python-six \
       sed \
-      zlib1g-dev && \
+      zlib1g-dev \
+      software-properties-common \
+      python-software-properties && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+# Install Python 3.6.
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -qy \
+      python3.6 \
+      python3.6-dev \
+      python3.6-venv && \
+    add-apt-repository --remove -y ppa:deadsnakes/ppa && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
Following the update of the CLI to Python 3, we embed Python 3.6 (the
minimum required Python version) into the Docker images used during
continuous integration.

Refs: cbdb6a5e1c0bb2e61dd0887cfae424ac2422b94d
Fixes: [MESOS-9229](https://issues.apache.org/jira/browse/MESOS-9229)