### PR TITLE
Fixed SIGINT handling in parallel test runner.

### DIFF
--- a/support/mesos-gtest-runner.py
+++ b/support/mesos-gtest-runner.py
@@ -32,7 +32,6 @@ import multiprocessing
 import os
 import resource
 import shlex
-import signal
 import subprocess
 import sys
 
@@ -73,8 +72,6 @@ def run_test(opts):
     """
     shard, nshards, args = opts
 
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
     env = os.environ.copy()
     env['GTEST_TOTAL_SHARDS'] = str(nshards)
     env['GTEST_SHARD_INDEX'] = str(shard)
@@ -88,6 +85,8 @@ def run_test(opts):
         print(Bcolors.colorize('.', Bcolors.OKGREEN), end='')
         sys.stdout.flush()
         return True, output
+    except KeyboardInterrupt:
+        return False
     except subprocess.CalledProcessError as error:
         print(Bcolors.colorize('.', Bcolors.FAIL), end='')
         sys.stdout.flush()


### PR DESCRIPTION
Previously, we were changing SIGINT signal handling by setting the
`SIG_IGN` flag in every worker from the worker pool. Hence, sending
SIGINT to `mesos-gtest-runner.py` led to leaks of `mesos-tests`
processes. This patch removes this handler to fix the issue.