### PR TITLE
Renamed `CGROUPS_ROOT` to `ROOT_CGROUPS` in tests for consistency.

### DIFF
--- a/src/tests/containerizer/memory_pressure_tests.cpp
+++ b/src/tests/containerizer/memory_pressure_tests.cpp
@@ -74,7 +74,7 @@ public:
 };
 
 
-TEST_F(MemoryPressureMesosTest, CGROUPS_ROOT_Statistics)
+TEST_F(MemoryPressureMesosTest, ROOT_CGROUPS_Statistics)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -197,7 +197,7 @@ TEST_F(MemoryPressureMesosTest, CGROUPS_ROOT_Statistics)
 
 
 // Test that memory pressure listening is restarted after recovery.
-TEST_F(MemoryPressureMesosTest, CGROUPS_ROOT_SlaveRecovery)
+TEST_F(MemoryPressureMesosTest, ROOT_CGROUPS_SlaveRecovery)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1937,7 +1937,7 @@ public:
 // Test the scenario where the network isolator is asked to recover
 // both types of containers: containers that were previously managed
 // by network isolator, and containers that weren't.
-TEST_F(PortMappingMesosTest, CGROUPS_ROOT_RecoverMixedContainers)
+TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedContainers)
 {
   master::Flags masterFlags = CreateMasterFlags();
 
@@ -2118,7 +2118,7 @@ TEST_F(PortMappingMesosTest, CGROUPS_ROOT_RecoverMixedContainers)
 
 // Test that all configurations (tc filters etc) is cleaned up for an
 // orphaned container using the network isolator.
-TEST_F(PortMappingMesosTest, CGROUPS_ROOT_CleanUpOrphan)
+TEST_F(PortMappingMesosTest, ROOT_CGROUPS_CleanUpOrphan)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);
@@ -2348,7 +2348,7 @@ TEST_F(PortMappingMesosTest, ROOT_NetworkNamespaceHandleSymlink)
 // This test verifies that the isolator is able to recover a mix of
 // known and unknown orphans. This is used to capture the regression
 // described in MESOS-2914.
-TEST_F(PortMappingMesosTest, CGROUPS_ROOT_RecoverMixedKnownAndUnKnownOrphans)
+TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedKnownAndUnKnownOrphans)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);

--- a/src/tests/slave_recovery_tests.cpp
+++ b/src/tests/slave_recovery_tests.cpp
@@ -5199,7 +5199,7 @@ TEST_F(MesosContainerizerSlaveRecoveryTest, ResourceStatistics)
 #ifdef __linux__
 // Test that a container started without namespaces/pid isolation can
 // be destroyed correctly with namespaces/pid isolation enabled.
-TEST_F(MesosContainerizerSlaveRecoveryTest, CGROUPS_ROOT_PidNamespaceForward)
+TEST_F(MesosContainerizerSlaveRecoveryTest, ROOT_CGROUPS_PidNamespaceForward)
 {
   Try<Owned<cluster::Master>> master = this->StartMaster();
   ASSERT_SOME(master);
@@ -5312,7 +5312,7 @@ TEST_F(MesosContainerizerSlaveRecoveryTest, CGROUPS_ROOT_PidNamespaceForward)
 
 // Test that a container started with namespaces/pid isolation can
 // be destroyed correctly without namespaces/pid isolation enabled.
-TEST_F(MesosContainerizerSlaveRecoveryTest, CGROUPS_ROOT_PidNamespaceBackward)
+TEST_F(MesosContainerizerSlaveRecoveryTest, ROOT_CGROUPS_PidNamespaceBackward)
 {
   Try<Owned<cluster::Master>> master = this->StartMaster();
   ASSERT_SOME(master);


### PR DESCRIPTION
See summary.