### PR TITLE
MESOS-9499 extended URI syntax to support any Zookeeper authentication schemes

### DIFF
--- a/include/mesos/zookeeper/authentication.hpp
+++ b/include/mesos/zookeeper/authentication.hpp
@@ -40,8 +40,6 @@ struct Authentication
     : scheme(_scheme),
       credentials(_credentials)
   {
-    // TODO(benh): Fix output operator below once this changes.
-    CHECK_EQ(scheme, "digest") << "Unsupported authentication scheme";
   }
 
   const std::string scheme;
@@ -62,9 +60,7 @@ inline std::ostream& operator<<(
     std::ostream& stream,
     const Authentication& authentication)
 {
-  // TODO(benh): Fix this once we support more than just 'digest'.
-  CHECK_EQ(authentication.scheme, "digest");
-  return stream << authentication.credentials;
+  return stream << authentication.scheme << "!" << authentication.credentials;
 }
 
 } // namespace zookeeper {


### PR DESCRIPTION
Zookeeper URL now optionally can have syntax:
zk://zk_auth_scheme!zk_auth_data@host:port/path

If there is no "!" in URL it works as before with digest auth scheme.

For example, I use it with our Zk auth plugin like this:
zk://simple!login:password@127.0.0.1:2181/mesos
Here "simple" is an authentication scheme name.