### PR TITLE
MESOS-6874: Validate the match between Type and *Infos in the ContainerInfo.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -3328,6 +3328,8 @@ message TTYInfo {
  */
 message ContainerInfo {
   // All container implementation types.
+  // For each type there should be a field in the ContainerInfo itself
+  // with exactly matching name in lowercase.
   enum Type {
     DOCKER = 1;
     MESOS = 2;
@@ -3381,8 +3383,8 @@ message ContainerInfo {
   repeated Volume volumes = 2;
   optional string hostname = 4;
 
-  // Only one of the following *Info messages should be set to match
-  // the type.
+  // At most one of the following *Info messages should be set to match
+  // the type, i.e. the "protobuf union" in ContainerInfo should be valid.
   optional DockerInfo docker = 3;
   optional MesosInfo mesos = 5;
 

--- a/src/common/validation.cpp
+++ b/src/common/validation.cpp
@@ -32,6 +32,8 @@
 
 #include <stout/os/constants.hpp>
 
+#include "common/protobuf_utils.hpp"
+
 using std::string;
 
 using google::protobuf::RepeatedPtrField;
@@ -264,6 +266,11 @@ Option<Error> validateVolume(const Volume& volume)
 
 Option<Error> validateContainerInfo(const ContainerInfo& containerInfo)
 {
+  Option<Error> unionError = protobuf::validateProtobufUnion(containerInfo);
+  if (unionError.isSome()) {
+    return unionError;
+  }
+
   foreach (const Volume& volume, containerInfo.volumes()) {
     Option<Error> error = validateVolume(volume);
     if (error.isSome()) {

--- a/src/master/validation.cpp
+++ b/src/master/validation.cpp
@@ -979,6 +979,13 @@ Option<Error> validateExecutorID(const ExecutorInfo& executor)
 
 Option<Error> validateType(const ExecutorInfo& executor)
 {
+  if (executor.has_container()) {
+    Option<Error> unionError =
+      protobuf::validateProtobufUnion(executor.container());
+    if (unionError.isSome()) {
+      return unionError;
+    }
+  }
   switch (executor.type()) {
     case ExecutorInfo::DEFAULT:
       if (executor.has_command()) {

--- a/src/tests/master_validation_tests.cpp
+++ b/src/tests/master_validation_tests.cpp
@@ -3374,6 +3374,57 @@ TEST_F(TaskValidationTest, TaskMissingDockerInfo)
   driver.join();
 }
 
+// This test verifies that a task that has `ContainerInfo` set as MESOS
+// but has a `DockerInfo` is rejected during `TaskInfo` validation.
+TEST_F(TaskValidationTest, TaskMesosTypeWithDockerInfo)
+{
+  Try<Owned<cluster::Master>> master = StartMaster();
+  ASSERT_SOME(master);
+
+  Owned<MasterDetector> detector = master.get()->createDetector();
+  Try<Owned<cluster::Slave>> slave = StartSlave(detector.get());
+  ASSERT_SOME(slave);
+
+  MockScheduler sched;
+  MesosSchedulerDriver driver(
+      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+  EXPECT_CALL(sched, registered(&driver, _, _));
+
+  Future<vector<Offer>> offers;
+  EXPECT_CALL(sched, resourceOffers(&driver, _))
+    .WillOnce(FutureArg<1>(&offers))
+    .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+  driver.start();
+
+  AWAIT_READY(offers);
+  ASSERT_FALSE(offers->empty());
+
+  Future<TaskStatus> status;
+  EXPECT_CALL(sched, statusUpdate(&driver, _))
+    .WillOnce(FutureArg<1>(&status));
+
+  // Create an invalid task that has `ContainerInfo` set
+  // as MESOS and has a `DockerInfo` set.
+  TaskInfo task = createTask(offers.get()[0], "exit 0");
+  task.mutable_container()->set_type(ContainerInfo::MESOS);
+  task.mutable_container()->mutable_docker()->set_image("alpine");
+
+  driver.launchTasks(offers.get()[0].id(), {task});
+
+  AWAIT_READY(status);
+  EXPECT_EQ(TASK_ERROR, status->state());
+  EXPECT_EQ(
+    "Task's `ContainerInfo` is invalid: "
+    "Protobuf union `mesos.ContainerInfo` with `Type == MESOS` "
+    "should not have the field `docker` set.",
+    status->message());
+
+  driver.stop();
+  driver.join();
+}
+
 
 // This test verifies that a task that has `name` parameter set
 // in `DockerInfo` is rejected during `TaskInfo` validation.
@@ -3531,6 +3582,21 @@ TEST_F(ExecutorValidationTest, ExecutorType)
         error->message,
         "'ExecutorInfo.container.mesos.image' must not be set for "
         "'DEFAULT' executor"));
+  }
+  {
+    // Invalid protobuf union in ContainerInfo.
+    executorInfo.set_type(ExecutorInfo::CUSTOM);
+    executorInfo.mutable_command();
+    executorInfo.mutable_container()->set_type(ContainerInfo::DOCKER);
+    executorInfo.mutable_container()->mutable_mesos();
+
+    Option<Error> error = ::executor::internal::validateType(executorInfo);
+
+    EXPECT_SOME(error);
+    EXPECT_TRUE(strings::contains(
+      error->message,
+      "Protobuf union `mesos.ContainerInfo` with `Type == DOCKER` "
+      "should not have the field `mesos` set."));
   }
 }
 


### PR DESCRIPTION
To avoid situations like described in [MESOS-6874](https://issues.apache.org/jira/browse/MESOS-6874), I'm clarifying the validity criteria for the `ContainerInfo` protobuf and adding validation of this protobuf into the ComposingContainerizer.

There basically has been three ways to validate this protobuf:
1. hardcoded check
2. labelling all the *Infos with protobuf options and use some protobuf reflection
3. require exact match between the Type enum members and the *Info fields, and use a bit more reflection.

Hardcoded check will not "scale well" in case more container types are added. Protobuf options are not a good option in our case (mesos.proto constututes a part of an external interface and adding an option there would require to register it globally). That's why I opted for the third option.

I'm also adding a test for this validation: passing ContainerInfo with Type==MESOS and docker set should make the ComposingContainerizer fail.

After adding this validation I discovered an invalid ContainerInfo used in the test DefaultExecutorWithDockerImageCommandHealthCheck. This PR contains a fix for this test.

Testing done:
- run make check after adding the test only: test expectedly fails
- run make check after adding validation code and fixing the problem with the health check  test: tests pass.