### PR TITLE
Fix link::lo to deal with None value.

### DIFF
--- a/src/linux/routing/link/link.cpp
+++ b/src/linux/routing/link/link.cpp
@@ -99,7 +99,7 @@ Result<string> lo()
     Result<bool> test = link::internal::test(link, IFF_LOOPBACK);
     if (test.isError()) {
       return Error("Failed to check the flag on link: " + link);
-    } else if (test.get()) {
+    } else if (test.isSome() && test.get()) {
       return link;
     }
   }


### PR DESCRIPTION
Some network links may cause link::internal::test(link, IFF_LOOPBACK) to be None.
Link::lo should deal with None values of test var.
[Jira issue](https://issues.apache.org/jira/browse/MESOS-9707)