### PR TITLE
Fix build with unbundled ELFIO

### DIFF
--- a/3rdparty/libprocess/configure.ac
+++ b/3rdparty/libprocess/configure.ac
@@ -599,7 +599,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable

--- a/3rdparty/stout/configure.ac
+++ b/3rdparty/stout/configure.ac
@@ -338,7 +338,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable

--- a/configure.ac
+++ b/configure.ac
@@ -1027,7 +1027,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable


### PR DESCRIPTION
Fixes autoconf error when detecting unbundled elfio headers when building with the `--with-elfio` flag. Autoconf is incorrectly looking for an `elfio.h` rather than the `elfio.hpp` C++ header.

```
checking elfio/elfio.h usability... 
no checking elfio/elfio.h presence... 
no checking for elfio/elfio.h... 
no configure: error: Cannot find the ELFIO headers
```
