### PR TITLE
Fix detection of ELFIO header

### DIFF
--- a/3rdparty/libprocess/configure.ac
+++ b/3rdparty/libprocess/configure.ac
@@ -599,7 +599,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable

--- a/3rdparty/stout/configure.ac
+++ b/3rdparty/stout/configure.ac
@@ -338,7 +338,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable

--- a/configure.ac
+++ b/configure.ac
@@ -1027,7 +1027,7 @@ if test "x$without_bundled_elfio" = "xyes" || \
      CPPFLAGS="-I${with_elfio} $CPPFLAGS"
   fi
 
-  AC_CHECK_HEADERS([elfio/elfio.h], [],
+  AC_CHECK_HEADERS([elfio/elfio.hpp], [],
                    [AC_MSG_ERROR([Cannot find the ELFIO headers
 -------------------------------------------------------------------
 You have requested the use of a non-bundled ELFIO but no suitable


### PR DESCRIPTION
Build fails to detect system provided ELFIO headers when using `configure --with-elfio` flag. Basically this is the same fix as the patch provided here: [https://issues.apache.org/jira/browse/MESOS-6605](https://issues.apache.org/jira/browse/MESOS-6605)
