### PR TITLE
Added mesos-resource-provider-sdk in client libraries.

### DIFF
--- a/docs/api-client-libraries.md
+++ b/docs/api-client-libraries.md
@@ -53,7 +53,7 @@ run into any issues, file them with the library maintainers.*
   <td>Go</td>
 </tr>
 <tr>
-  <td><a href="https://github.com/verizonlabs/mesos-framework-sdk">
+  <td><a href="https://github.com/carlonelong/mesos-framework-sdk">
   mesos-framework-sdk</a></td>
   <td>Go</td>
 </tr>
@@ -143,5 +143,23 @@ run into any issues, file them with the library maintainers.*
   <td>
     Go
   </td>
+</tr>
+</table>
+
+## Resource Provider API
+
+### User Contributed
+
+*Note: These libraries are supported by their authors, so if you
+run into any issues, file them with the library maintainers.*
+
+<table class="table table-bordered">
+<thead>
+<tr><th>Name</th><th>Language</th>
+</thead>
+<tr>
+  <td><a href="https://github.com/carlonelong/mesos-resource-provider-sdk">
+  mesos-resource-provider-sdk</a></td>
+  <td>Go</td>
 </tr>
 </table>


### PR DESCRIPTION
I wrote a resource provider sdk in Go for mesos, which worked fine on my ARM chips. 

Also, since the [mesos-framework-sdk](https://github.com/verizonlabs/mesos-framework-sdk) is no longer maintained, I forked it and added some features. 

I'm not sure if it's OK to replace the link in the doc.