### PR TITLE
Documentation: Garbage Collection - Nanoseconds

### DIFF
--- a/docs/container-image.md
+++ b/docs/container-image.md
@@ -430,7 +430,7 @@ or as a JSON object,
     --image_gc_config="{ \
       \"image_disk_headroom\": 0.1, \
       \"image_disk_watch_interval\": { \
-        \"nano_seconds\": 3600 \
+        \"nanoseconds\": 3600000000000 \
         }, \
       \"excluded_images\": \[ \] \
     }"


### PR DESCRIPTION
Hello! 

While recently enabling garbage collection in our mesos cluster we came across this inconsistency in the documentation for garbage collection. This PR fixes an example which used "nano_seconds" instead of "nanoseconds". Using a json with `"nanoseconds": 3600000000000` works fine for us so far. :)

Thanks for your amazing work on mesos!

Best,
Hans