### PR TITLE
Removed the link to mesos.slackarchive.io

### DIFF
--- a/site/source/community.html.md
+++ b/site/source/community.html.md
@@ -41,8 +41,6 @@ layout: community_section
 
     <p>To request an invite for slack please click <a href="https://mesos-slackin.herokuapp.com">here</a>.</p>
 
-    <p>All slack communication is publicly archived <a href="http://mesos.slackarchive.io">here</a>.</p>
-
     <p>Thank you <a href="https://www.criteo.com">Criteo</a> for sponsoring Slack standard plan.</p>
 
 


### PR DESCRIPTION
slackarchive.io is no longer active. Also, since we upgraded to Slack's standard plan, archiving is built-in.