### PR TITLE
Add wargaming.net url to Powered By Mesos Page

### DIFF
--- a/docs/powered-by-mesos.md
+++ b/docs/powered-by-mesos.md
@@ -122,6 +122,7 @@ layout: documentation
 * [Verizon Labs](https://www.verizon.com/about/our-company/what-we-do)
 * [Viadeo](http://www.viadeo.com)
 * [Virdata](http://www.virdata.com)
+* [Wargaming](http://www.wargaming.net/)
 * [Weibo](http://weibo.com/)
 * [Whisk](http://www.whisk.com)
 * [Wizcorp](http://www.wizcorp.jp)


### PR DESCRIPTION
Wargaming uses Mesos clusters at least 4 years. I think, we should add it to the Page.