### PR TITLE
Handle EBUSY when destroying a cgroup.

### DIFF
--- a/docs/contributors.yaml
+++ b/docs/contributors.yaml
@@ -231,6 +231,12 @@
   jira_user: drcrallen
   reviewboard_user: drcrallen
 
+- name: Charles-Francois Natali
+  emails:
+    - cf.natali@gmail.com
+  jira_user: cf.natali
+  reviewboard_user: cf.natali
+
 - name: Chen Runcong
   affiliations:
     - {organization: Asiainfo}

--- a/src/linux/cgroups.hpp
+++ b/src/linux/cgroups.hpp
@@ -201,20 +201,6 @@ Try<Nothing> create(
     bool recursive = false);
 
 
-// Remove a cgroup in a given hierarchy. To remove a cgroup, one needs
-// to remove the corresponding directory in the cgroups virtual file
-// system. A cgroup cannot be removed if it has processes or
-// sub-cgroups inside. This function does nothing but tries to remove
-// the corresponding directory of the given cgroup. It will return
-// error if the remove operation fails because it has either processes
-// or sub-cgroups inside. The cgroup will NOT be removed recursively.
-// This function assumes that the given hierarchy and cgroup are
-// valid.
-// @param   hierarchy   Path to the hierarchy root.
-// @param   cgroup      Path to the cgroup relative to the hierarchy root.
-Try<Nothing> remove(const std::string& hierarchy, const std::string& cgroup);
-
-
 // Returns true if the given cgroup under a given hierarchy exists.
 // @param   hierarchy   Path to the hierarchy root.
 // @param   cgroup      Path to the cgroup relative to the hierarchy root.

--- a/src/tests/containerizer/cgroups_isolator_tests.cpp
+++ b/src/tests/containerizer/cgroups_isolator_tests.cpp
@@ -1489,7 +1489,8 @@ TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_CreateRecursively)
   // We should remove cgroups_root after the slave being started
   // because slave will create cgroups_root dir during startup
   // if it's not present.
-  ASSERT_SOME(cgroups::remove(hierarchy.get(), flags.cgroups_root));
+  ASSERT_SOME(os::rmdir(
+        path::join(hierarchy.get(), flags.cgroups_root), false));
   ASSERT_FALSE(os::exists(flags.cgroups_root));
 
   MockScheduler sched;

--- a/src/tests/containerizer/cgroups_tests.cpp
+++ b/src/tests/containerizer/cgroups_tests.cpp
@@ -377,9 +377,9 @@ TEST_F(CgroupsAnyHierarchyWithCpuMemoryTest, ROOT_CGROUPS_CreateRemove)
   EXPECT_ERROR(cgroups::create(baseHierarchy, "mesos_test_missing/1"));
   ASSERT_SOME(cgroups::create(
         path::join(baseHierarchy, "cpu"), "mesos_test_missing"));
-  EXPECT_ERROR(cgroups::remove(baseHierarchy, "invalid"));
-  ASSERT_SOME(cgroups::remove(
-        path::join(baseHierarchy, "cpu"), "mesos_test_missing"));
+  EXPECT_ERROR(os::rmdir(path::join(baseHierarchy, "invalid"), false));
+  ASSERT_SOME(os::rmdir(path::join(
+        path::join(baseHierarchy, "cpu"), "mesos_test_missing"), false));
 }
 
 
@@ -398,8 +398,8 @@ TEST_F(CgroupsAnyHierarchyTest, ROOT_CGROUPS_Get)
   EXPECT_NE(cgroups->end(),
             find(cgroups->begin(), cgroups->end(), "mesos_test1"));
 
-  ASSERT_SOME(cgroups::remove(hierarchy, "mesos_test1"));
-  ASSERT_SOME(cgroups::remove(hierarchy, "mesos_test2"));
+  ASSERT_SOME(os::rmdir(path::join(hierarchy, "mesos_test1"), false));
+  ASSERT_SOME(os::rmdir(path::join(hierarchy, "mesos_test2"), false));
 }
 
 
@@ -431,8 +431,8 @@ TEST_F(CgroupsAnyHierarchyTest, ROOT_CGROUPS_NestedCgroups)
   EXPECT_NE(cgroups->end(),
             find(cgroups->begin(), cgroups->end(), cgroup1));
 
-  ASSERT_SOME(cgroups::remove(hierarchy, cgroup1));
-  ASSERT_SOME(cgroups::remove(hierarchy, cgroup2));
+  ASSERT_SOME(os::rmdir(path::join(hierarchy, cgroup1), false));
+  ASSERT_SOME(os::rmdir(path::join(hierarchy, cgroup2), false));
 }
 
 


### PR DESCRIPTION
It's a workaround for kernel bugs
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/kernel/cgroup/cgroup.c?id=9c974c77246460fa6a92c18554c3311c8c83c160
and
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/kernel/cgroup/cgroup.c?id=c03cd7738a83b13739f00546166969342c8ff014

Fixes https://issues.apache.org/jira/browse/MESOS-10107

@abudnik 

> Does the workaround work reliably after changing the initial delay and retry count to the values taken from libcontainerd (10ms and 5)?

Yes, however I chose 1ms and 10 for two reasons:
- this possibly yields lower latency
- more importantly, while doing an strace I can see that it can take sometimes up to around 100-200ms for rmdir to succeed:

```
[pid  1965] 13:22:36.021260 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000017>
[pid  1965] 13:22:36.022604 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000018>
[pid  1965] 13:22:36.024807 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000080>
[pid  1965] 13:22:36.029116 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000466>
[pid  1965] 13:22:36.037990 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000190>
[pid  1965] 13:22:36.054528 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000038>
[pid  1965] 13:22:36.086874 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = -1 EBUSY (Périphérique ou ressource occupé) <0.000029>
[pid  3225] 13:22:36.127365 +++ killed by SIGKILL +++
[pid  1965] 13:22:36.151151 rmdir("/sys/fs/cgroup/freezer/mesos/b99efad6-b9eb-43bd-8242-29a2b321dd07") = 0 <0.000114>
```

And 10ms with 5 retries only 320ms (10 * 2**5), so I'd rather have a bit more margin.

> Should we retry only if `::rmdir()` returns EBUSY errno error?

Definitely - I wanted to do that but I'm not sure what's the best way to do it: is there a way to access `errno` from `Try<Nothing> rmdir` or can I just assume that the global `errno` is preserved and access it directly?