### PR TITLE
Fixed missing find_if namespace qualification

### DIFF
--- a/src/master/quota.cpp
+++ b/src/master/quota.cpp
@@ -109,7 +109,7 @@ Try<bool> UpdateQuota::perform(
     google::protobuf::RepeatedPtrField<Registry::Quota>& quotas =
       *registry->mutable_quotas();
 
-    int quotaIndex = find_if(
+    int quotaIndex = std::find_if(
         quotas.begin(),
         quotas.end(),
         [&](const Registry::Quota& quota) {


### PR DESCRIPTION
See 0273fbc2638c581528cc5819da2e0c9b1a9c235e for why this is needed. This one was just left out from that commit, but is included in FreeBSD's patches.