### PR TITLE
Made the cgroup listener stop logging spurious error on finalization.

### DIFF
--- a/src/linux/cgroups.cpp
+++ b/src/linux/cgroups.cpp
@@ -1167,7 +1167,11 @@ protected:
     // TODO(chzhcn): Fail our promise only after 'reading' has
     // completed (ready, failed or discarded).
     if (promise.isSome()) {
-      promise.get()->fail("Event listener is terminating");
+      if (promise.get()->future().hasDiscard()) {
+        promise.get()->discard();
+      } else {
+        promise.get()->fail("Event listener is terminating");
+      }
     }
   }
 


### PR DESCRIPTION
Before, running any task would cause the following error to be logged
when the OOM listener was finalized:

```
E0418 14:13:25.575969 31596 memory.cpp:637] Listening on OOM events failed for container 65e9cbb5-2e29-4cac-bc98-2723a359a652: Event listener is terminating                                                                                                                  
```

The error originates in the OOM listener finalization: https://github.com/apache/mesos/blob/master/src/linux/cgroups.cpp#L1170

Logging an error might make sense, but maybe not if the future was discarded, which the memory subsystem does upon cleanup: https://github.com/apache/mesos/blob/master/src/slave/containerizer/mesos/isolators/cgroups/subsystems/memory.cpp#L586

This removes a lot of noise from the logs, which also makes debugging a bit easier by avoid following red-herrings.