### PR TITLE
MESOS-10129 Build fails on Maven javadoc generation when using JDK11

### DIFF
--- a/src/java/mesos.pom.in
+++ b/src/java/mesos.pom.in
@@ -86,6 +86,7 @@
         <configuration>
           <sourcepath>@abs_top_srcdir@/src/java/src:@abs_top_builddir@/src/java/generated</sourcepath>
           <subpackages>org.apache.mesos</subpackages>
+          <detectJavaApiLink>false</detectJavaApiLink>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Maven Javadoc plugin tries to include non-existant java6 documentation references and it fails ... this fix tries to skip those invalid references for the Javadoc plugin to success (it also works for Java8 and Java11)