### PR TITLE
Fix FreeBSD memory detection (MESOS-10104)

### DIFF
--- a/3rdparty/stout/include/stout/os/freebsd.hpp
+++ b/3rdparty/stout/include/stout/os/freebsd.hpp
@@ -88,17 +88,28 @@ inline Try<Memory> memory()
   const size_t pageSize = os::pagesize();
 
   unsigned int freeCount;
-  size_t length = sizeof(freeCount);
-
+  size_t freeCountLength = sizeof(freeCount);
   if (sysctlbyname(
-      "vm.stats.v_free_count",
+      "vm.stats.vm.v_free_count",
       &freeCount,
-      &length,
+      &freeCountLength,
       nullptr,
       0) != 0) {
     return ErrnoError();
   }
-  memory.free = Bytes(freeCount * pageSize);
+
+  unsigned int inactiveCount;
+  size_t inactiveCountLength = sizeof(inactiveCount);
+  if (sysctlbyname(
+      "vm.stats.vm.v_inactive_count",
+      &inactiveCount,
+      &inactiveCountLength,
+      nullptr,
+      0) != 0) {
+    return ErrnoError();
+  }
+
+  memory.free = Bytes((freeCount + inactiveCount) * pageSize);
 
   int totalBlocks = 0;
   int usedBlocks = 0;
@@ -112,8 +123,9 @@ inline Try<Memory> memory()
   // FreeBSD supports multiple swap devices. Here we sum across all of them.
   struct xswdev xswd;
   size_t xswdSize = sizeof(xswd);
-  int* mibDevice = &(mib[mibSize + 1]);
-  for (*mibDevice = 0; ; (*mibDevice)++) {
+  for (int ndev = 0; ; ndev++) {
+      mib[mibSize] = ndev;
+
       if (::sysctl(mib, 3, &xswd, &xswdSize, nullptr, 0) != 0) {
           if (errno == ENOENT) {
               break;

--- a/3rdparty/stout/tests/os_tests.cpp
+++ b/3rdparty/stout/tests/os_tests.cpp
@@ -1289,3 +1289,19 @@ TEST_F(OsTest, Which)
   which = os::which("bar");
   EXPECT_NONE(which);
 }
+
+TEST_F(OsTest, Memory)
+{
+  Try<os::Memory> memory = os::memory();
+  ASSERT_SOME(memory);
+  
+  // Verify total memory is greater than zero.
+  EXPECT_GT(memory->total, 0);
+
+  // Verify free memory is greater than zero and less than total.
+  EXPECT_GT(memory->free, 0);
+  EXPECT_LT(memory->free, memory->total);
+
+  // Verify freeSwap is less than or equal to totalSwap (both can be zero)
+  EXPECT_LE(memory->freeSwap, memory->totalSwap);
+}


### PR DESCRIPTION
Fixed detection of available free memory and swap.
Tested on FreeBSD-12.1-STABLE (sysutils/apache-mesos port)

https://issues.apache.org/jira/browse/MESOS-10104