### PR TITLE
[MESOS-10199] Fix Host field in client headers

### DIFF
--- a/3rdparty/libprocess/src/encoder.hpp
+++ b/3rdparty/libprocess/src/encoder.hpp
@@ -122,7 +122,7 @@ public:
         << "User-Agent: libprocess/" << message.from << "\r\n"
         << "Libprocess-From: " << message.from << "\r\n"
         << "Connection: Keep-Alive\r\n"
-        << "Host: \r\n";
+        << "Host: " << message.to.address << "\r\n";
 
     if (message.body.size() > 0) {
       out << "Transfer-Encoding: chunked\r\n\r\n"

--- a/3rdparty/libprocess/src/tests/process_tests.cpp
+++ b/3rdparty/libprocess/src/tests/process_tests.cpp
@@ -1445,9 +1445,11 @@ TEST_F(ProcessTest, Remote)
   RemoteProcess process;
   spawn(process);
 
-  Future<Nothing> handler;
+  Future<UPID> pid;
+  Future<string> body;
   EXPECT_CALL(process, handler(_, _))
-    .WillOnce(FutureSatisfy(&handler));
+    .WillOnce(DoAll(FutureArg<0>(&pid),
+                    FutureArg<1>(&body)));
 
   Try<Socket> create = Socket::create();
   ASSERT_SOME(create);
@@ -1463,12 +1465,17 @@ TEST_F(ProcessTest, Remote)
   message.name = "handler";
   message.from = UPID("sender", sender.get());
   message.to = process.self();
+  message.body = "hello world";
 
   const string data = MessageEncoder::encode(message);
 
   AWAIT_READY(socket.send(data));
 
-  AWAIT_READY(handler);
+  AWAIT_READY(body);
+  ASSERT_EQ("hello world", body.get());
+
+  AWAIT_READY(pid);
+  ASSERT_EQ(message.from, pid.get());
 
   terminate(process);
   wait(process);


### PR DESCRIPTION
This PR replaces empty host with actual IP/Port of the message recipient in Host field. IP+Port has been used as per RFC guidelines.
An earlier PR made host field empty https://reviews.apache.org/r/27865