### PR TITLE
Fix flaky MasterTest.NonCheckpointingFrameworkAgentDisconnectionExecutorOnly.

### DIFF
--- a/src/tests/master_tests.cpp
+++ b/src/tests/master_tests.cpp
@@ -7785,6 +7785,11 @@ TEST_F(MasterTest, NonCheckpointingFrameworkAgentDisconnectionExecutorOnly)
   // disconnection since the framework's failover timeout is 0.
   driver.stop(true);
 
+  // Make sure it reaches the master.
+  Clock::pause();
+  Clock::settle();
+  Clock::resume();
+
   // Check to make sure the framework is removed.
   {
     v1::master::Call call;


### PR DESCRIPTION
After stopping the driver, we need to wait for the events to reach the
master before checking that the framework has been removed.

It could be reproduced with the following:
```
$ ./bin/mesos-tests.sh --gtest_repeat=-1 --gtest_break_on_failure --gtest_filter=MasterTest.NonCheckpointingFrameworkAgentDisconnectionExecutorOnly 
[...]
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MasterTest
[ RUN      ] MasterTest.NonCheckpointingFrameworkAgentDisconnectionExecutorOnly
../../src/tests/master_tests.cpp:7797: Failure
      Expected: 0
To be equal to: response->get_frameworks().frameworks_size()
      Which is: 1
*** Aborted at 1611689737 (unix time) try "date -d @1611689737" if you are using GNU date ***
PC: @     0x555e47d02d6d testing::UnitTest::AddTestPartResult()
*** SIGSEGV (@0x0) received by PID 12751 (TID 0x7fbac1607b00) from PID 0; stack trace: ***
    @     0x7fbac2d91730 (unknown)
    @     0x555e47d02d6d testing::UnitTest::AddTestPartResult()
    @     0x555e47cf5b7f testing::internal::AssertHelper::operator=()
    @     0x555e46bf3cdb mesos::internal::tests::MasterTest_NonCheckpointingFrameworkAgentDisconnectionExecutorOnly_Test::TestBody()
    @     0x555e47d225f0 testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x555e47d1cdb0 testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x555e47cfc896 testing::Test::Run()
    @     0x555e47cfd104 testing::TestInfo::Run()
    @     0x555e47cfd74d testing::TestCase::Run()
    @     0x555e47d04299 testing::internal::UnitTestImpl::RunAllTests()
    @     0x555e47d233c6 testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x555e47d1d8e6 testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x555e47d02f90 testing::UnitTest::Run()
    @     0x555e468d509b RUN_ALL_TESTS()
    @     0x555e468d4b15 main
    @     0x7fbac2be209b __libc_start_main
    @     0x555e45a374ca _start
Segmentation fault
```

@bmahler 