### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -892,7 +892,7 @@ message Object {
 }
 ```
 
-`Subject` or `Object` are optional fiels; if they are not set they
+`Subject` or `Object` are optional fields; if they are not set they
 will only match an ACL with ANY or NONE in the
 corresponding location. This allows users to construct the following requests:
 _Can everybody perform action **A** on object **O**?_, or _Can principal **Z**

--- a/docs/building.md
+++ b/docs/building.md
@@ -92,7 +92,7 @@ Following are the instructions for Mac OS X El Capitan. When building Mesos with
 
 When compiling on macOS 10.12, the following is needed:
 
-    # There is an incompatiblity with the system installed svn and apr headers.
+    # There is an incompatibility with the system installed svn and apr headers.
     # We need the svn and apr headers from a brew installation of subversion.
     # You may need to unlink the existing version of subversion installed via
     # brew in order to configure correctly.

--- a/docs/configuration/cmake.md
+++ b/docs/configuration/cmake.md
@@ -182,7 +182,7 @@ See more information in the [CMake documentation](../cmake.md).
     <td>
       Location of the dependency mirror. In some cases, the Mesos build system
       needs to acquire third-party dependencies that aren't rebundled as
-      tarballs in the Mesos repository. For example, on Windows, we must aquire
+      tarballs in the Mesos repository. For example, on Windows, we must acquire
       newer versions of some dependencies, and since Windows does not have a
       package manager, we must acquire system dependencies like cURL. This
       parameter can be either a URL (for example, pointing at the Mesos official


### PR DESCRIPTION
Scope of changes is restricted to docs only. Changes are made in agreement with Standard American English.