### PR TITLE
Fixed read of uninitialized variables detected with UBSAN.

### DIFF
--- a/src/tests/cluster.hpp
+++ b/src/tests/cluster.hpp
@@ -106,7 +106,8 @@ public:
   void setAuthorizationCallbacks(Authorizer* authorizer);
 
 private:
-  Master() : files(master::READONLY_HTTP_AUTHENTICATION_REALM) {};
+  Master() : files(master::READONLY_HTTP_AUTHENTICATION_REALM),
+             authorizationCallbacksSet(false) {}
 
   // Not copyable, not assignable.
   Master(const Master&) = delete;
@@ -203,7 +204,8 @@ public:
   void setAuthorizationCallbacks(Authorizer* authorizer);
 
 private:
-  Slave() : files(slave::READONLY_HTTP_AUTHENTICATION_REALM) {};
+  Slave() : files(slave::READONLY_HTTP_AUTHENTICATION_REALM),
+            authorizationCallbacksSet(false) {}
 
   // Not copyable, not assignable.
   Slave(const Slave&) = delete;


### PR DESCRIPTION
@asekretenko @qianzhangxa 

They were detected as invalid boolean values.

I'll look at adding a `configure` flag to build with UBSAN, I need to look at potential remaining false positives.