### PR TITLE
Fixed compilation error on CAP_(PERFMON,BPF,CHECKPOINT_RESTORE).

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -3378,9 +3378,9 @@ message CapabilityInfo {
     WAKE_ALARM = 1035;
     BLOCK_SUSPEND = 1036;
     AUDIT_READ = 1037;
-    CAP_PERFMON = 1038;
-    CAP_BPF = 1039;
-    CAP_CHECKPOINT_RESTORE = 1040;
+    PERFMON = 1038;
+    BPF = 1039;
+    CHECKPOINT_RESTORE = 1040;
   }
 
   repeated Capability capabilities = 1;

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -3367,9 +3367,9 @@ message CapabilityInfo {
     WAKE_ALARM = 1035;
     BLOCK_SUSPEND = 1036;
     AUDIT_READ = 1037;
-    CAP_PERFMON = 1038;
-    CAP_BPF = 1039;
-    CAP_CHECKPOINT_RESTORE = 1040;
+    PERFMON = 1038;
+    BPF = 1039;
+    CHECKPOINT_RESTORE = 1040;
   }
 
   repeated Capability capabilities = 1;

--- a/src/linux/capabilities.cpp
+++ b/src/linux/capabilities.cpp
@@ -494,9 +494,9 @@ ostream& operator<<(ostream& stream, const Capability& capability)
     case WAKE_ALARM:              return stream << "WAKE_ALARM";
     case BLOCK_SUSPEND:           return stream << "BLOCK_SUSPEND";
     case AUDIT_READ:              return stream << "AUDIT_READ";
-    case CAP_PERFMON:             return stream << "CAP_PERFMON";
-    case CAP_BPF:                 return stream << "CAP_BPF";
-    case CAP_CHECKPOINT_RESTORE:  return stream << "CAP_CHECKPOINT_RESTORE";
+    case PERFMON:                 return stream << "PERFMON";
+    case BPF:                     return stream << "BPF";
+    case CHECKPOINT_RESTORE:      return stream << "CHECKPOINT_RESTORE";
     case MAX_CAPABILITY:          UNREACHABLE();
   }
 

--- a/src/linux/capabilities.hpp
+++ b/src/linux/capabilities.hpp
@@ -72,9 +72,9 @@ enum Capability : int
   WAKE_ALARM             = 35,
   BLOCK_SUSPEND          = 36,
   AUDIT_READ             = 37,
-  CAP_PERFMON            = 38,
-  CAP_BPF                = 39,
-  CAP_CHECKPOINT_RESTORE = 40,
+  PERFMON                = 38,
+  BPF                    = 39,
+  CHECKPOINT_RESTORE     = 40,
   MAX_CAPABILITY         = 41,
 };
 


### PR DESCRIPTION
They should be defined without the "CAP_" prefix to avoid clashing with
the corresponding definitions in `linux/capability.h` - and be
consistent with other capabilities.

@asekretenko 