### PR TITLE
Fixed parsing of `perf` output on some locales.

### DIFF
--- a/src/linux/perf.cpp
+++ b/src/linux/perf.cpp
@@ -125,6 +125,12 @@ protected:
 private:
   void execute()
   {
+    // If the locale is such that `LC_NUMERIC` uses the comma ',' as decimal
+    // separator, parsing won't work - because of unexpected number of fields
+    // and floating points format - so make sure it's set to `C`.
+    std::map<string, string> env = os::environment();
+    env["LC_ALL"] = "C";
+
     // NOTE: The supervisor childhook places perf in its own process group
     // and will kill the perf process when the parent dies.
     Try<Subprocess> _perf = subprocess(
@@ -134,7 +140,7 @@ private:
         Subprocess::PIPE(),
         Subprocess::PIPE(),
         nullptr,
-        None(),
+        env,
         None(),
         {},
         {Subprocess::ChildHook::SUPERVISOR()});


### PR DESCRIPTION
If the locale is such that `LC_NUMERIC` uses the comma ',' as decimal
separator, parsing won't work - because of unexpected number of fields
and floating points format - so make sure it's set to `C`.

Example:
```
[ RUN      ]
CgroupsAnyHierarchyWithPerfEventTest.ROOT_CGROUPS_PERF_PerfTest
../../src/tests/containerizer/cgroups_tests.cpp:1024: Failure
(statistics).failure(): Failed to parse perf sample: Failed to parse
perf sample line
'6376827291,,cycles,mesos_test,2011741096,100,00,3,GHz': Unexpected
number of fields (9)
[  FAILED  ]
CgroupsAnyHierarchyWithPerfEventTest.ROOT_CGROUPS_PERF_PerfTest (2157
ms)
```

Standalone reproducer, using '/' as separator for readability:
```
root@thinkpad:~# LC_NUMERIC=fr_FR.UTF-8 perf stat --field-separator "/"
-- true
0,31/msec/task-clock/306721/100,00/0/CPUs utilized
0//context-switches/306721/100,00/0/K/sec
0//cpu-migrations/306721/100,00/0/K/sec
44//page-faults/306721/100,00/0/M/sec
788234//cycles/311478/100,00/2/GHz
538077//instructions/311478/100,00/0/insn per cycle
106749//branches/311478/100,00/348/M/sec
4556//branch-misses/311478/100,00/4/of all branches
```