### PR TITLE
Backported fix for picojson -Wparentheses warning with recent GCC. 

### DIFF
--- a/3rdparty/picojson-1.3.0.patch
+++ b/3rdparty/picojson-1.3.0.patch
@@ -204,3 +204,29 @@ index ed9656d..b04ed59 100644
  }
 --
 2.17.1
+From 62b52d4c43531cfb285c2c72c785485b84911867 Mon Sep 17 00:00:00 2001
+From: Charles-Francois Natali <cf.natali@gmail.com>
+Date: Sat, 12 Jun 2021 18:50:18 +0100
+Subject: [PATCH] Backported fix for -Wparentheses warning with recent GCC
+ versions.
+
+---
+ picojson.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/picojson.h b/picojson.h
+index 48bb64e..ae4fda6 100644
+--- a/picojson.h
++++ b/picojson.h
+@@ -301,7 +301,7 @@ namespace picojson {
+   GET(array, *u_.array_)
+   GET(object, *u_.object_)
+ #ifdef PICOJSON_USE_INT64
+-  GET(double, (type_ == int64_type && (const_cast<value*>(this)->type_ = number_type, const_cast<value*>(this)->u_.number_ = u_.int64_), u_.number_))
++  GET(double, (type_ == int64_type && (const_cast<value*>(this)->type_ = number_type, (const_cast<value*>(this)->u_.number_ = u_.int64_)), u_.number_))
+   GET(int64_t, u_.int64_)
+ #else
+   GET(double, u_.number_)
+-- 
+2.30.2
+


### PR DESCRIPTION
In order to fix a compilation warning under recent gcc versions.
It also contains a patch which we used to maintain ourselves.

Note that since version 1.3.1 hasn't been released - picojson doesn't
seem actively maintained - this is really just the current master, and
I'm including the short commit hash in the version to indicate exactly
which version we're using.

Compilation warning:
```
../3rdparty/picojson-1.3.0/picojson.h: In member function ‘const T& picojson::value::get() const [with T = double]’:
../3rdparty/picojson-1.3.0/picojson.h:304:124: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  304 |   GET(double, (type_ == int64_type && (const_cast<value*>(this)->type_ = number_type, const_cast<value*>(this)->u_.number_ = u_.int64_), u_.number_))
      |                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../3rdparty/picojson-1.3.0/picojson.h:292:12: note: in definition of macro ‘GET’
  292 |     return var;       \
```

Fix for the compilation warning:
https://github.com/kazuho/picojson/commit/c8853367b0ad6ff6e76188e639a8e7f0706d4431

The patch we used to maintain ourselves:
https://github.com/apache/mesos/blob/master/3rdparty/picojson-1.3.0.patch

Upstream commit corresponding to this patch:
https://github.com/kazuho/picojson/commit/2f9d3cf33808615376493469c4be6942fc3c987a
And follow-up commit:
https://github.com/kazuho/picojson/commit/35ce0b6b03e0b60541258f5ad061003a696d9a34

@asekretenko @qianzhangxa 