### PR TITLE
Backported a boost-mpl commit to ignore GCC's -Wparentheses.

### DIFF
--- a/3rdparty/boost-1.65.0.patch
+++ b/3rdparty/boost-1.65.0.patch
@@ -16,3 +16,49 @@ index c0557de71..c06eaea45 100644
 -#     pragma message("Unknown compiler version - please run the configure tests and report the results")
 -#  endif
 -#endif
+From f48fd09d021db9a28bd7b8452c175897e1af4485 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Thu, 1 Mar 2018 09:59:33 +0100
+Subject: [PATCH] Ignore gcc 8 warnings.
+
+---
+ boost/mpl/assert.hpp | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/boost/mpl/assert.hpp b/boost/mpl/assert.hpp
+index 1af1b058..e41b583c 100644
+--- a/boost/mpl/assert.hpp
++++ b/boost/mpl/assert.hpp
+@@ -184,16 +184,27 @@ template< typename P > struct assert_arg_pred_not
+     typedef typename assert_arg_pred_impl<p>::type type;
+ };
+ 
++#if defined(BOOST_GCC) && BOOST_GCC >= 80000
++#define BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wparentheses"
++#endif
++
+ template< typename Pred >
+-failed ************ (Pred::************ 
++failed ************ (Pred::************
+       assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type )
+     );
+ 
+ template< typename Pred >
+-failed ************ (boost::mpl::not_<Pred>::************ 
++failed ************ (boost::mpl::not_<Pred>::************
+       assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type )
+     );
+ 
++#ifdef BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#undef BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#pragma GCC diagnostic pop
++#endif
++
+ template< typename Pred >
+ AUX778076_ASSERT_ARG(assert<false>)
+ assert_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type );
+-- 
+2.30.2
+


### PR DESCRIPTION
In order to allow us to build with `-Werror`.
Since boost is quite a large dependency and the change is so small, it
felt much simpler and less risky than updating boost just to silence
this warning.

See https://github.com/boostorg/mpl/pull/34 for the upstream fix.

This together with https://github.com/apache/mesos/pull/392 allows to build with `-Werror` using this somewhat recent gcc:
```
gcc (Debian 10.2.1-6) 10.2.1 20210110
```

@asekretenko @qianzhangxa 

