### PR TITLE
Fixed crashes on ARM64 due to bad interaction of libunwind with libgcc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -857,11 +857,19 @@ AS_IF([test "x$enable_parallel_test_execution" = "xyes"],
 AS_IF([test "x$enable_werror" != "xno"],
       [AC_SUBST([WERROR], [-Werror])])
 
-# Check for libunwind, and link it in if present.
+# Check for libunwind - used by glog for tracebacks - and link it in if
+# present.
+# `-lgcc_s` is necessary on e.g. ARM64 and IA-64, see
+# https://bugzilla.redhat.com/show_bug.cgi?id=480412
+# Notes:
+# - Omitting it causes glog to link it anyway, resulting in the same problem.
+# - If `-lgcc_s` isn't available, e.g. if compiling with a pure LLVM toolchain,
+#   then we won't link it here but glog will link it anyway, but it won't suffer
+#   from the problem which affects only libgcc.
 if test "x$OS_NAME" = "xfreebsd"; then
   AC_CHECK_LIB(execinfo, backtrace, LIBS="$LIBS -lexecinfo")
 else
-  AC_CHECK_LIB(unwind, backtrace, LIBS="$LIBS -lunwind")
+  AC_CHECK_LIB(unwind, backtrace, LIBS="$LIBS -lgcc_s -lunwind")
 fi
 
 


### PR DESCRIPTION
Mesos is currently unusable on ARM64 - and probably other architectures.
Here's an example test failure:
```
[ RUN      ] JsonTest.ParseError
terminate called after throwing an instance of 'std::overflow_error'
terminate called recursively
*** Aborted at 1622796321 (unix time) try "date -d @1622796321" if you
are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x3e80000090c) received by PID 2316 (TID 0xffff918cf010)
from PID 2316; stack trace: ***
    @     0xffff918dd7fc ([vdso]+0x7fb)
    @     0xffff91367188 gsignal
    @     0xffff91353dac abort
    @     0xffff91569848 __gnu_cxx::__verbose_terminate_handler()
    @     0xffff915671ec (unknown)
    @     0xffff91567250 std::terminate()
    @     0xffff915675b0 __cxa_rethrow
    @     0xffff915697e4 __gnu_cxx::__verbose_terminate_handler()
    @     0xffff915671ec (unknown)
    @     0xffff91567250 std::terminate()
    @     0xffff91567544 __cxa_throw
    @     0xaaaab4e3d324 picojson::value::value()
    @     0xaaaab4e421d8 JSON::internal::ParseContext::set_number()
    @     0xaaaab4e52140 picojson::_parse<>()
    @     0xaaaab4e63e74
JSON::internal::ParseContext::parse_object_item<>()
    @     0xaaaab4e5ae34 picojson::_parse_object<>()
    @     0xaaaab4e51fd4 picojson::_parse<>()
    @     0xaaaab4e49e18 picojson::_parse<>()
    @     0xaaaab4e426e4 JSON::parse()
    @     0xaaaab4e4a38c JSON::parse<>()
    @     0xaaaab4ecce28 JsonTest_ParseError_Test::TestBody()
    @     0xaaaab5186fec
testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0xaaaab517f1d4
testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0xaaaab515a9d0 testing::Test::Run()
    @     0xaaaab515b258 testing::TestInfo::Run()
    @     0xaaaab515b8d0 testing::TestCase::Run()
    @     0xaaaab5162344 testing::internal::UnitTestImpl::RunAllTests()
    @     0xaaaab5188440
testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0xaaaab517ffd4
testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0xaaaab516100c testing::UnitTest::Run()
    @     0xaaaab4f30950 RUN_ALL_TESTS()
    @     0xaaaab4f30418 main
```

Looking at the code shows that exceptions which are supposed to be
caught are actually not caught- see e.g. `std::overflow_error` which should be
caught here: https://github.com/apache/mesos/blob/3777b3a0ca01972d80aac435e057c4fe20ef8b51/3rdparty/stout/include/stout/json.hpp#L1003
causing `std::terminate` to be called,
and `std::terminate` itself breaks and is called recursively.

It can be reproduced with the following code:
```
charles-natali@martin-arm64:~$ cat test.cpp

int main()
{
    try {
        throw std::overflow_error("");
    } catch (const std::overflow_error&) {
    }
}
```

This works, as expected:
```
charles-natali@martin-arm64:~$ g++ -o test test.cpp && ./test
charles-natali@martin-arm64:~$
```

However linking with `-lunwind` - which is used by glog to get
tracebacks in case of fatal error and linked here:
https://github.com/apache/mesos/blob/96339efb53f7cdf1126ead7755d2b83b435e3263/configure.ac#L864)
breaks exception handling:
```
charles-natali@martin-arm64:~$ g++ -o test test.cpp -lunwind && ./test
terminate called after throwing an instance of 'std::overflow_error'
terminate called recursively
Aborted (core dumped)
charles-natali@martin-arm64:~$
```

The reasons are explained in this bug report - for IA-64 but the problem
is the same on ARM64 - but basically it breaks libgcc unwinding code:
https://bugzilla.redhat.com/show_bug.cgi?id=480412

The solution is to make sure we pass `-lgcc_s` before `-lunwind`:
```
charles-natali@martin-arm64:~$ g++ -o test test.cpp -lgcc_s -lunwind &&
./test;
charles-natali@martin-arm64:~$
```

Tested on both x86-64 and ARM64, with gcc (whole Mesos test suite) and
clang (only standalone reproducer).

Closes MESOS-10223.



@qianzhangxa 