### PR TITLE
MESOS-10225: Update documentation to systemd's parameter delegate

### DIFF
--- a/docs/mesos-containerizer.md
+++ b/docs/mesos-containerizer.md
@@ -66,3 +66,14 @@ Mesos supports the following built-in isolators.
 - [volume/secret](secrets.md#file-based-secrets)
 - [windows/cpu](isolators/windows.md#cpu-limits)
 - [windows/mem](isolators/windows.md#memory-limits)
+
+## Systemd Integration
+
+To prevent systemd from manipulating cgroups managed by the agent, 
+it's recommended to add 'Delegate' under 'Service' in the service 
+unit file of Mesos agent, for example:
+<pre><code>
+[Service]
+Delegate=true
+
+</code></pre>

--- a/support/packaging/common/mesos-slave.service
+++ b/support/packaging/common/mesos-slave.service
@@ -11,6 +11,7 @@ RestartSec=20
 LimitNOFILE=16384
 CPUAccounting=true
 MemoryAccounting=true
+Delegate=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With these PR I would like to add the systemd parameter "delegate" into the documentation of the mesos-agent. 
See Issue: https://issues.apache.org/jira/browse/MESOS-10225

Therefore these PR would not remove our asf.yaml file (https://github.com/apache/mesos-site/pull/2), I also add it into the middleman build process. I know, normally it should be two PR's. 