### PR TITLE
LinkedHashMap: fixed handling of self-assignment.

### DIFF
--- a/3rdparty/stout/include/stout/linkedhashmap.hpp
+++ b/3rdparty/stout/include/stout/linkedhashmap.hpp
@@ -46,13 +46,15 @@ public:
 
   LinkedHashMap& operator=(const LinkedHashMap<Key, Value>& other)
   {
-    clear();
+    if (this != &other) {
+      clear();
 
-    entries_ = other.entries_;
+      entries_ = other.entries_;
 
-    // Build up the index.
-    for (auto it = entries_.begin(); it != entries_.end(); ++it) {
-      keys_[it->first] = it;
+      // Build up the index.
+      for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+        keys_[it->first] = it;
+      }
     }
 
     return *this;

--- a/3rdparty/stout/tests/linkedhashmap_tests.cpp
+++ b/3rdparty/stout/tests/linkedhashmap_tests.cpp
@@ -236,4 +236,11 @@ TEST(LinkedHashMapTest, Assignment)
 
   EXPECT_NE(map.keys(), copy.keys());
   EXPECT_NE(map.values(), copy.values());
+
+  // Test self-assignment.
+  copy = map;
+  map = map;
+
+  EXPECT_EQ(copy.keys(), map.keys());
+  EXPECT_EQ(copy.values(), map.values());
 }


### PR DESCRIPTION
Self-assigning a LinkedHashMap i.e. `map = map` would cause the map
to be cleared.
Found with clang-tidy.


@asekretenko @qianzhangxa 