### PR TITLE
[MESOS-10229] Cherry-Pick 1.11.x: Backport fixes to enable building 1.11.x on Ubuntu 20.04

### DIFF
--- a/3rdparty/boost-1.65.0.patch
+++ b/3rdparty/boost-1.65.0.patch
@@ -16,3 +16,49 @@ index c0557de71..c06eaea45 100644
 -#     pragma message("Unknown compiler version - please run the configure tests and report the results")
 -#  endif
 -#endif
+From f48fd09d021db9a28bd7b8452c175897e1af4485 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Thu, 1 Mar 2018 09:59:33 +0100
+Subject: [PATCH] Ignore gcc 8 warnings.
+
+---
+ boost/mpl/assert.hpp | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/boost/mpl/assert.hpp b/boost/mpl/assert.hpp
+index 1af1b058..e41b583c 100644
+--- a/boost/mpl/assert.hpp
++++ b/boost/mpl/assert.hpp
+@@ -184,16 +184,27 @@ template< typename P > struct assert_arg_pred_not
+     typedef typename assert_arg_pred_impl<p>::type type;
+ };
+ 
++#if defined(BOOST_GCC) && BOOST_GCC >= 80000
++#define BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wparentheses"
++#endif
++
+ template< typename Pred >
+-failed ************ (Pred::************ 
++failed ************ (Pred::************
+       assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type )
+     );
+ 
+ template< typename Pred >
+-failed ************ (boost::mpl::not_<Pred>::************ 
++failed ************ (boost::mpl::not_<Pred>::************
+       assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type )
+     );
+ 
++#ifdef BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#undef BOOST_MPL_IGNORE_PARENTHESES_WARNING
++#pragma GCC diagnostic pop
++#endif
++
+ template< typename Pred >
+ AUX778076_ASSERT_ARG(assert<false>)
+ assert_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type );
+-- 
+2.30.2
+

--- a/3rdparty/grpc-1.10.0.patch
+++ b/3rdparty/grpc-1.10.0.patch
@@ -86,3 +86,122 @@ index 83f642a675..8e2253fb39 100644
 -- 
 2.17.2 (Apple Git-113)
 
+From 46911818fec7886f0057b321e387c7c5a67a76b1 Mon Sep 17 00:00:00 2001
+From: Juanli Shen <juanlishen@google.com>
+Date: Fri, 23 Aug 2019 08:46:09 -0700
+Subject: [PATCH 1/2] Fix gettid() naming conflict
+
+---
+ src/core/lib/gpr/log_linux.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
+index d743eedf38..3c6a08839d 100644
+--- a/src/core/lib/gpr/log_linux.cc
++++ b/src/core/lib/gpr/log_linux.cc
+@@ -39,7 +39,9 @@
+ #include <time.h>
+ #include <unistd.h>
+ 
+-static long gettid(void) { return syscall(__NR_gettid); }
++// Not naming it as gettid() to avoid duplicate declarations when complied with
++// GCC 9.1.
++static long local_gettid(void) { return syscall(__NR_gettid); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -65,7 +67,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+   struct tm tm;
+   static __thread long tid = 0;
+-  if (tid == 0) tid = gettid();
++  if (tid == 0) tid = local_gettid();
+ 
+   timer = static_cast<time_t>(now.tv_sec);
+   final_slash = strrchr(args->file, '/');
+-- 
+2.29.2
+
+From 8626f961aeea5770b013214c26218e806051b598 Mon Sep 17 00:00:00 2001
+From: Benjamin Peterson <benjamin@dropbox.com>
+Date: Fri, 3 May 2019 08:11:00 -0700
+Subject: [PATCH 2/2] Rename gettid() functions.
+
+glibc 2.30 will declare its own gettid; see https://sourceware.org/git/?p=glibc.git;a=commit;h=1d0fc213824eaa2a8f8c4385daaa698ee8fb7c92. Rename the grpc versions to avoid naming conflicts.
+---
+ src/core/lib/gpr/log_linux.cc          | 6 ++----
+ src/core/lib/gpr/log_posix.cc          | 4 ++--
+ src/core/lib/iomgr/ev_epollex_linux.cc | 4 ++--
+ 3 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
+index 3c6a08839d..b7cf86cd9b 100644
+--- a/src/core/lib/gpr/log_linux.cc
++++ b/src/core/lib/gpr/log_linux.cc
+@@ -39,9 +39,7 @@
+ #include <time.h>
+ #include <unistd.h>
+ 
+-// Not naming it as gettid() to avoid duplicate declarations when complied with
+-// GCC 9.1.
+-static long local_gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -67,7 +65,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+   struct tm tm;
+   static __thread long tid = 0;
+-  if (tid == 0) tid = local_gettid();
++  if (tid == 0) tid = sys_gettid();
+ 
+   timer = static_cast<time_t>(now.tv_sec);
+   final_slash = strrchr(args->file, '/');
+diff --git a/src/core/lib/gpr/log_posix.cc b/src/core/lib/gpr/log_posix.cc
+index 6f93cdefcd..39d943964f 100644
+--- a/src/core/lib/gpr/log_posix.cc
++++ b/src/core/lib/gpr/log_posix.cc
+@@ -30,7 +30,7 @@
+ #include <string.h>
+ #include <time.h>
+ 
+-static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
++static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -81,7 +81,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   char* prefix;
+   gpr_asprintf(&prefix, "%s%s.%09d %7tu %s:%d]",
+                gpr_log_severity_string(args->severity), time_buffer,
+-               (int)(now.tv_nsec), gettid(), display_file, args->line);
++               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
+ 
+   fprintf(stderr, "%-70s %s\n", prefix, args->message);
+   gpr_free(prefix);
+diff --git a/src/core/lib/iomgr/ev_epollex_linux.cc b/src/core/lib/iomgr/ev_epollex_linux.cc
+index bb7622c4cc..a28d356835 100644
+--- a/src/core/lib/iomgr/ev_epollex_linux.cc
++++ b/src/core/lib/iomgr/ev_epollex_linux.cc
+@@ -981,7 +981,7 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
+ }
+ 
+ #ifndef NDEBUG
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long sys_gettid(void) { return syscall(__NR_gettid); }
+ #endif
+ 
+ /* pollset->mu lock must be held by the caller before calling this.
+@@ -1001,7 +1001,7 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
+ #define WORKER_PTR (&worker)
+ #endif
+ #ifndef NDEBUG
+-  WORKER_PTR->originator = gettid();
++  WORKER_PTR->originator = sys_gettid();
+ #endif
+   if (grpc_polling_trace.enabled()) {
+     gpr_log(GPR_DEBUG,
+-- 
+2.29.2
+

--- a/3rdparty/grpc.md
+++ b/3rdparty/grpc.md
@@ -29,3 +29,11 @@ We bundle 1.10.0 for better CMake build support.
 - [CMake: Automatic fallbacking on system's OpenSSL if it only has NPN.](https://github.com/chhsia0/grpc/commit/5c13ad2a3df1108184c716379818eab6fc0ba72d)
 
   Upstream PR: https://github.com/grpc/grpc/pull/17726
+
+- [Fix gettid() naming conflict.](https://github.com/grpc/grpc/commit/de6255941a5e1c2fb2d50e57f84e38c09f45023d)
+
+  Upstream PR: https://github.com/grpc/grpc/pull/20048
+
+- [Rename gettid() functions.](https://github.com/grpc/grpc/commit/57586a1ca7f17b1916aed3dea4ff8de872dbf853)
+
+  Upstream PR: https://github.com/grpc/grpc/pull/18950


### PR DESCRIPTION
Cherry-picks https://github.com/apache/mesos/commit/4ce33ca185fde0c6b258b85311fde3384e488f0d and https://github.com/apache/mesos/commit/7141572d64cc43d3aafe2b4f5de7492cc0803b78 in order to enable building 1.11.x on Ubuntu 20.04