### PR TITLE
Refactored the Python CLI code.

### DIFF
--- a/src/python/cli_new/lib/cli/http.py
+++ b/src/python/cli_new/lib/cli/http.py
@@ -64,13 +64,11 @@ def read_endpoint(addr, endpoint, config, query=None):
                            .format(url=url, error=str(exception)))
 
 
-def get_json(addr, endpoint, config, condition=None, query=None):
+def get_json(addr, endpoint, config, query=None):
     """
-    Return the contents of the 'endpoint' at 'addr' as JSON data
-    subject to the condition specified in 'condition'. If we are
-    unable to read the data we throw an error.
+    Return the contents of the 'endpoint' at 'addr' as JSON data.
+    If we are unable to read the data we throw an error.
     """
-
     data = read_endpoint(addr, endpoint, config, query)
 
     try:
@@ -78,11 +76,5 @@ def get_json(addr, endpoint, config, condition=None, query=None):
     except Exception as exception:
         raise CLIException("Could not load JSON from '{data}': {error}"
                            .format(data=data, error=str(exception)))
-
-    if not condition:
-        return data
-
-    if condition(data):
-        return data
 
     return data

--- a/src/python/cli_new/lib/cli/mesos.py
+++ b/src/python/cli_new/lib/cli/mesos.py
@@ -49,13 +49,8 @@ def get_agent_address(agent_id, master, config):
     Given a master and an agent id, return the agent address
     by checking the /slaves endpoint of the master.
     """
-    try:
-        agents = http.get_json(master, "slaves", config)["slaves"]
-    except Exception as exception:
-        raise CLIException("Could not open '/slaves'"
-                           " endpoint at '{addr}': {error}"
-                           .format(addr=master,
-                                   error=exception))
+    agents = get_agents(master, config)
+
     for agent in agents:
         if agent["id"] == agent_id:
             return agent["pid"].split("@")[1]
@@ -68,6 +63,35 @@ def get_agents(master, config):
     """
     endpoint = "slaves"
     key = "slaves"
+    return get_key_endpoint(key, endpoint, master, config)
+
+def get_framework_address(framework_id, master, config):
+    """
+    Given a master and an framework id, return the framework address
+    by checking the /master/frameworks endpoint of the master.
+    """
+    frameworks = get_frameworks(master, config)
+
+    for framework in frameworks:
+        if framework["id"] == framework_id:
+            return framework["webui_url"]
+    raise CLIException("Unable to find framework '{id}'"
+                       .format(id=framework_id))
+
+
+def get_frameworks(master, config):
+    """
+    Get the frameworks in a Mesos cluster.
+    """
+    endpoint = "master/frameworks/"
+    key = "frameworks"
+    return get_key_endpoint(key, endpoint, master, config)
+
+
+def get_key_endpoint(key, endpoint, master, config):
+    """
+    Get the json key of the given endpoint
+    """
     try:
         data = http.get_json(master, endpoint, config)
     except Exception as exception:
@@ -121,7 +145,7 @@ def get_tasks(master, config, query=None):
     key = "tasks"
 
     if query is None:
-        query = {'order':'asc'}
+        query = {'order':'asc', 'limit':'-1'}
 
     try:
         data = http.get_json(master, endpoint, config, query=query)

--- a/src/python/cli_new/lib/cli/tests/agent.py
+++ b/src/python/cli_new/lib/cli/tests/agent.py
@@ -48,7 +48,8 @@ class TestAgentPlugin(CLITestCase):
 
         # Open the master's `/slaves` endpoint and read the
         # agents' information ourselves.
-        agents = http.get_json(master.addr, None, 'slaves')["slaves"]
+        agents = http.get_json(master.addr, 'slaves',
+                               config.Config(None))["slaves"]
 
         self.assertEqual(type(agents), list)
         self.assertEqual(len(agents), 1)


### PR DESCRIPTION
Like I promised in PR#405 (https://github.com/apache/mesos/pull/405), this is one of the three PR's I will open.  This PR will change:

- Remove unneeded conditions parameter to "filter" the json call. 
- Remove the limitation of "task list".
- Add global function to get the host address of a framework (for future use in plugins)
- Add global function to get all frameworks connected to mesos (for future use in plugins)

@cf-natali I will open the other two PR's when this one is reviewed. :-) 