### PR TITLE
ADD: framework plugin for the mesos-cli.

### DIFF
--- a/src/python/cli_new/bin/settings.py
+++ b/src/python/cli_new/bin/settings.py
@@ -40,7 +40,8 @@ PROJECT_DIR = os.path.join(os.path.dirname(__file__), os.pardir)
 PLUGINS = [
     os.path.join(PROJECT_DIR, "lib", "mesos", "plugins", "agent"),
     os.path.join(PROJECT_DIR, "lib", "mesos", "plugins", "config"),
-    os.path.join(PROJECT_DIR, "lib", "mesos", "plugins", "task")
+    os.path.join(PROJECT_DIR, "lib", "mesos", "plugins", "task"),
+    os.path.join(PROJECT_DIR, "lib", "mesos", "plugins", "framework")
 ]
 
 DEFAULT_MESOS_CLI_CONFIG = os.path.join(

--- a/src/python/cli_new/lib/cli/plugins/framework/__init__.py
+++ b/src/python/cli_new/lib/cli/plugins/framework/__init__.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Framework module.
+"""
+
+# pylint: disable=wildcard-import
+from .main import *
+

--- a/src/python/cli_new/lib/cli/plugins/framework/main.py
+++ b/src/python/cli_new/lib/cli/plugins/framework/main.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The framework plugin.
+"""
+
+import json
+
+from cli.exceptions import CLIException
+from cli.mesos import get_frameworks
+from cli.plugins import PluginBase
+from cli.util import Table
+
+
+PLUGIN_NAME = "framework"
+PLUGIN_CLASS = "Framework"
+
+VERSION = "v0.1.0"
+
+SHORT_HELP = "Interacts with the Mesos Frameworks"
+
+
+class Framework(PluginBase):
+    """
+    The framework plugin.
+    """
+
+    COMMANDS = {
+        "list": {
+            "arguments": [],
+            "flags": {
+                "-a --all": "include inactive frameworks"
+            },
+            "short_help": "List the Mesos frameworks.",
+            "long_help": "List information about the Mesos frameworks."
+        },
+        "inspect": {
+            "arguments": ['<framework_id>'],
+            "flags": {},
+            "short_help": "Return low-level information on the framework.",
+            "long_help": "Return low-level information on the framework."
+        }
+    }
+
+    def list(self, argv):
+        """
+        Show a list of running frameworks
+        """
+
+        try:
+            master = self.config.master()
+        except Exception as exception:
+            raise CLIException("Unable to get leading master address: {error}"
+                               .format(error=exception))
+
+        data = get_frameworks(master, self.config)
+        table = Table(["ID", "Active", "Hostname", "Name"])
+        for framework in data:
+            if (not argv["--all"] and not framework["active"]):
+                continue
+
+            active = "False"
+            if framework["active"]:
+                active = "True"
+
+            table.add_row([framework["id"],
+                           active,
+                           framework["hostname"],
+                           framework["name"]])
+
+        print(str(table))
+
+    def inspect(self, argv):
+        """
+        Show the low-level information of the framework.
+        """
+
+        try:
+            master = self.config.master()
+        except Exception as exception:
+            raise CLIException("Unable to get leading master address: {error}"
+                               .format(error=exception))
+
+        data = get_frameworks(master, self.config)
+        for framework in data:
+            if framework["id"] != argv["<framework_id>"]:
+                continue
+
+            # remove not helpfull information
+            framework.pop('tasks', None)
+            framework.pop('unreachable_tasks', None)
+            framework.pop('completed_tasks', None)
+
+            print(json.dumps(framework, indent=4))
+
+


### PR DESCRIPTION
These is the second part of my previous created PR https://github.com/apache/mesos/pull/405. With these PR I would like to add a plugin for the "new" mesos cli to list and inspect all running mesos frameworks.

```
> mesos framework

Interacts with the Mesos Frameworks

Usage:
  mesos framework (-h | --help)
  mesos framework --version
  mesos framework <command> (-h | --help)
  mesos framework [options] <command> [<args>...]

Options:
  -h --help  Show this screen.
  --version  Show version info.

Commands:
  inspect  Return low-level information of the framework.
  list     List the Mesos frameworks.

```