### PR TITLE
Fix fetcher cache reduction

### DIFF
--- a/src/slave/containerizer/fetcher.cpp
+++ b/src/slave/containerizer/fetcher.cpp
@@ -1229,7 +1229,7 @@ Try<Nothing> FetcherProcess::Cache::adjust(
     if (d <= 0) {
       entry->size = size.get();
 
-      releaseSpace(Bytes(d));
+      releaseSpace(Bytes(-d));
     } else {
       return Error("More cache size now necessary, not adjusting " +
                    entry->key);


### PR DESCRIPTION
When artifact size is smaller than expected, we want to reduce recorded
cache usage.

To do it, we actually compute the delta as an off_t (signed). If delta is
negative, we reclaim the extra space as it's not really used.

This attempt was failing because computed delta is negative,
and passed as Bytes to releaseSpace, which is unsigned. In
most cases, casting a negative value into an uint will
just give an unrelated value due to sign bit disappearing.

By passing the positive value to Bytes(), we have a safer cast.

To give more context, what we observe:
```
W1125 08:54:07.888011 10981 fetcher.cpp:643] URI download result for 'xxxxx' is smaller than expected by 253B at: /var/opt/mesos/cache/xxxxxxxx
F1125 08:54:07.888082 10981 fetcher.cpp:1272] Check failed: bytes <= tally Attempt to release more cache space than in use - requested: 18446744073709551364B, in use: 1910056052B
```

If you try
```
#include <stdio.h>
#include <stdint.h>

int main() {
    off_t negative = -253;
    printf("%lu\n", (uint64_t)(negative));
}
```
You'll see the same numbers match.