### PR TITLE
ADD: missing release notes, REMOVE: not working links.

### DIFF
--- a/site/data/releases.yml
+++ b/site/data/releases.yml
@@ -212,6 +212,10 @@ versions:
 ##                 after we create the ReleaseNote for 0.28.1, we get the link:
 ##                 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311242&version=12335359.
 ##                 At here, 12335359 is the jira_version of 0.28.1.
+  - version: 1.11.0
+    jira_version: 12348332
+  - version: 1.10.0
+    jira_version: 12346271
   - version: 1.8.1
     jira_version: 12345342
   - version: 1.9.0

--- a/site/source/downloads.html.erb
+++ b/site/source/downloads.html.erb
@@ -33,12 +33,6 @@ breadcrumb: Downloads
           <%= data.releases.latest_stable.version %>
           </a>
         </li>
-        <li>
-          RPM
-          <a href="https://bintray.com/apache/mesos/mesos/<%= data.releases.latest_stable.version %>">
-            <%= data.releases.latest_stable.version %>
-          </a>
-        </li>
       </ul>
       </p>
 
@@ -55,9 +49,5 @@ breadcrumb: Downloads
         This repository is also mirrored on
         <a href="https://github.com/apache/mesos">GitHub</a>.
       </p>
-
-      <h4>Getting older Mesos binaries</h4>
-      Some previous versions of Mesos can be downloaded from BinTray: <a href="https://bintray.com/apache/mesos">https://bintray.com/apache/mesos</a>.
-
   </div>
 </div>


### PR DESCRIPTION
These PR will remove the not working links to bintray at the download page. I also add the missing release notes to 1.10.0 and 1.11.0.