### PR TITLE
Cleanup: git >= 2.32 does not support gitignore as symlink.

### DIFF
--- a/support/setup-dev.sh
+++ b/support/setup-dev.sh
@@ -27,7 +27,8 @@ __EOF__
 fi
 
 if test ! -e .gitignore; then
-  ln -s support/gitignore .gitignore
+  # Git version 2.32.0 does not support gitignore as symlink (https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt)
+  cp support/gitignore .gitignore
 fi
 
 if test ! -e .reviewboardrc; then


### PR DESCRIPTION
Nothing important, only a cleanup.

Git version 2.32.0 does not support gitignore as symlink ([https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt](https://github.com/git/git/blob/master/Documentation/RelNotes/2.32.0.txt)). I updated setup-dev.sh to copy gitignore into the mesos root path. I also add some more filenames into gitignore. All of them was dynamically created by bootstrap.sh, setup-dev.sh and/or autoconf/make.