### PR TITLE
Enabled squash option for github PR.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,5 @@
+github:
+  enabled_merge_buttons:
+    merge:   false
+    rebase:  true
+    squash:  true


### PR DESCRIPTION
Squashing makes it easier to have a clean history and rewrite commit
messages without involving the original submitter, which might not be
aware of the project contribution guidelines.