### PR TITLE
Fixed mesos-tidy build parallelism.

### DIFF
--- a/support/mesos-tidy/entrypoint.sh
+++ b/support/mesos-tidy/entrypoint.sh
@@ -35,41 +35,41 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 
 # Set up CMake to run as many parallel build process as we have cores instead
 # of relying on the default parallelism of the particular build tool.
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
 
 # Build the external dependencies.
 # TODO(mpark): Use an external dependencies target once MESOS-6924 is resolved.
-cmake --build 3rdparty --parallel --target boost-1.65.0
-cmake --build 3rdparty --parallel --target elfio-3.2
-cmake --build 3rdparty --parallel --target glog-0.4.0
-cmake --build 3rdparty --parallel --target googletest-1.8.0
-cmake --build 3rdparty --parallel --target grpc-1.10.0
-cmake --build 3rdparty --parallel --target http_parser-2.6.2
+cmake --build 3rdparty --target boost-1.65.0
+cmake --build 3rdparty --target elfio-3.2
+cmake --build 3rdparty --target glog-0.4.0
+cmake --build 3rdparty --target googletest-1.8.0
+cmake --build 3rdparty --target grpc-1.10.0
+cmake --build 3rdparty --target http_parser-2.6.2
 
 # TODO(mpark): The `|| true` is a hack to try both `libev` and `libevent` and
 #              use whichever one happens to be configured. This would also go
 #              away with MESOS-6924.
-cmake --build 3rdparty --parallel --target libev-4.22 || true
-cmake --build 3rdparty --parallel --target libevent-2.1.5-beta || true
+cmake --build 3rdparty --target libev-4.22 || true
+cmake --build 3rdparty --target libevent-2.1.5-beta || true
 
-cmake --build 3rdparty --parallel --target leveldb-1.19
-cmake --build 3rdparty --parallel --target nvml-352.79
-cmake --build 3rdparty --parallel --target picojson-1.3.0
-cmake --build 3rdparty --parallel --target protobuf-3.5.0
-cmake --build 3rdparty --parallel --target zookeeper-3.4.8
+cmake --build 3rdparty --target leveldb-1.19
+cmake --build 3rdparty --target nvml-352.79
+cmake --build 3rdparty --target picojson-1.3.0
+cmake --build 3rdparty --target protobuf-3.5.0
+cmake --build 3rdparty --target zookeeper-3.4.8
 
 # Generate the protobuf definitions.
 # TODO(mpark): Use a protobuf generation target once MESOS-6925 is resolved.
-cmake --build . --parallel --target mesos-protobufs
+cmake --build . --target mesos-protobufs
 
 # For protobuf definitions in stout (`protobuf-test.pb.h`) or
 # libprocess (`grpc_tests.pb.h`, `grpc_tests.grpc.pb.h` and `benchmarks.pb.h`)
 # no explict targets exists; we instead build the executable targets to produce
 # them as a side-effect. This is pretty hacky for what we want to do, but it's
 # okay for now.
-cmake --build 3rdparty/stout/tests --parallel --target stout-tests
-cmake --build 3rdparty/libprocess/src/tests --parallel --target libprocess-tests
-cmake --build 3rdparty/libprocess/src/tests --parallel --target benchmarks
+cmake --build 3rdparty/stout/tests --target stout-tests
+cmake --build 3rdparty/libprocess/src/tests --target libprocess-tests
+cmake --build 3rdparty/libprocess/src/tests --target benchmarks
 
 # TODO(bbannier): Use a less restrictive `grep` pattern and `header-filter`
 # once MESOS-6115 is fixed.


### PR DESCRIPTION
- Export `CMAKE_BUILD_PARALLEL_LEVEL`, otherwise it's not passed to
  child cmake processes.
- Do not pass `--parallel` to cmake processes: if `--parallel` is passed
  without an argument, cmake/make will interpret it by default as
  unbounded parallelism, despite `CMAKE_BUILD_PARALLEL_LEVEL` being set.

After this change, the build parallelism is correctly set to the number
of cores instead of unbounded.