### PR TITLE
Added support for limiting mesos-tidy parallelism.

### DIFF
--- a/support/mesos-tidy.sh
+++ b/support/mesos-tidy.sh
@@ -19,6 +19,8 @@
 set -e
 set -o pipefail
 
+: "${JOBS:=$(nproc)}"
+
 MESOS_DIR=$(git rev-parse --show-toplevel)
 
 # Check for unstaged or uncommitted changes.
@@ -36,4 +38,5 @@ docker run \
   -v "${MESOS_DIR}":/SRC:Z \
   -e CHECKS="${CHECKS}" \
   -e CMAKE_ARGS="${CMAKE_ARGS}" \
+  -e JOBS="${JOBS}" \
   mesos/mesos-tidy

--- a/support/mesos-tidy/entrypoint.sh
+++ b/support/mesos-tidy/entrypoint.sh
@@ -33,9 +33,9 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       ${CMAKE_ARGS} \
       "${SRCDIR}"
 
-# Set up CMake to run as many parallel build process as we have cores instead
-# of relying on the default parallelism of the particular build tool.
-export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+# Specify CMake parallelism instead of relying on the default parallelism of
+# the particular build tool.
+export CMAKE_BUILD_PARALLEL_LEVEL="${JOBS}"
 
 # Build the external dependencies.
 # TODO(mpark): Use an external dependencies target once MESOS-6924 is resolved.
@@ -78,7 +78,7 @@ cat compile_commands.json \
   | sed 's/"//g' \
   | sed 's/^\ //g' \
   | grep "^${SRCDIR}/.*\.cpp$" \
-  | parallel -j $(nproc) clang-tidy -p "${PWD}" \
+  | parallel -j "${JOBS}" clang-tidy -p "${PWD}" \
       -extra-arg=-Wno-unknown-warning-option \
       -extra-arg=-Wno-unused-command-line-argument \
       -header-filter="^${SRCDIR}/.*\.hpp$" -checks="${CHECKS}" \


### PR DESCRIPTION
Instead of seting the parallelism to the number of cores, allow it to be
overwritten on an ad-hoc basis via the `JOBS` environment variable,
similar to mesos-build.

This is useful for example to avoid running OOM, which I suspect is
what's happening on the Jenkins CI.