### PR TITLE
Fixed mesos-tidy to actually log clang-tidy errors on failure.

### DIFF
--- a/support/mesos-tidy/entrypoint.sh
+++ b/support/mesos-tidy/entrypoint.sh
@@ -82,7 +82,7 @@ cat compile_commands.json \
       -extra-arg=-Wno-unknown-warning-option \
       -extra-arg=-Wno-unused-command-line-argument \
       -header-filter="^${SRCDIR}/.*\.hpp$" -checks="${CHECKS}" \
-  1> clang-tidy.log 2> /dev/null
+  1> clang-tidy.log 2> /dev/null || true
 
 # Propagate any errors.
 if test -s clang-tidy.log; then


### PR DESCRIPTION
Because it uses `set -e`, the `entrypoint.sh` script would exit -
silently - if `clang-tidy` exited with a non-zero exit status, without
showing the `clang-tidy` output.