### PR TITLE
Fixed clang-tidy warnings due to capturing this in a deferred lambda.

### DIFF
--- a/src/csi/v0_volume_manager.cpp
+++ b/src/csi/v0_volume_manager.cpp
@@ -1075,7 +1075,7 @@ Future<Nothing> VolumeManagerProcess::__publishVolume(const string& volumeId)
 
   if (!volumeState.node_stage_secrets().empty()) {
     rpcResult = resolveSecrets(volumeState.node_stage_secrets())
-      .then([=](const Map<string, string>& secrets) {
+      .then(process::defer(self(), [=](const Map<string, string>& secrets) {
         NodeStageVolumeRequest request_(request);
         *request_.mutable_node_stage_secrets() = secrets;
 
@@ -1083,7 +1083,7 @@ Future<Nothing> VolumeManagerProcess::__publishVolume(const string& volumeId)
             NODE_SERVICE,
             &Client::nodeStageVolume,
             std::move(request_));
-      });
+      }));
   } else {
     rpcResult =
       call(NODE_SERVICE, &Client::nodeStageVolume, std::move(request));

--- a/src/csi/v1_volume_manager.cpp
+++ b/src/csi/v1_volume_manager.cpp
@@ -1114,7 +1114,7 @@ Future<Nothing> VolumeManagerProcess::__publishVolume(const string& volumeId)
 
   if (!volumeState.node_stage_secrets().empty()) {
     rpcResult = resolveSecrets(volumeState.node_stage_secrets())
-      .then([=](const Map<string, string>& secrets) {
+      .then(process::defer(self(), [=](const Map<string, string>& secrets) {
         NodeStageVolumeRequest request_(request);
         *request_.mutable_secrets() = secrets;
 
@@ -1122,7 +1122,7 @@ Future<Nothing> VolumeManagerProcess::__publishVolume(const string& volumeId)
             NODE_SERVICE,
             &Client::nodeStageVolume,
             std::move(request_));
-      });
+      }));
   } else {
     rpcResult =
       call(NODE_SERVICE, &Client::nodeStageVolume, std::move(request));


### PR DESCRIPTION
Use `defer(self(), lambda)` instead to avoid the risk of use-after-free.

See on the mesos-tidy CI job:
```
/tmp/SRC/src/csi/v0_volume_manager.cpp:1078:13: warning: callback
capturing this should be dispatched/deferred to a specific PID
[mesos-this-capture]
      .then([=](const Map<string, string>& secrets) {
```

Together with the recent fixes merged, this fix should allow the
mesos-tidy CI job to be green again:
https://ci-builds.apache.org/job/Mesos/job/Mesos-Tidybot/