### PR TITLE
Revert "Fixed random SlaveRecoveryTest.PingTimeoutDuringRecovery test failure."

### DIFF
--- a/src/tests/slave_recovery_tests.cpp
+++ b/src/tests/slave_recovery_tests.cpp
@@ -1010,15 +1010,6 @@ TYPED_TEST(SlaveRecoveryTest, PingTimeoutDuringRecovery)
 
   slave.get()->terminate();
 
-  // Make sure that timers started by the previous slave's process expire,
-  // because we reuse the same PID we don't want them to fire while the
-  // new process is running.
-  Clock::pause();
-  Clock::advance(masterFlags.agent_ping_timeout *
-    masterFlags.max_agent_ping_timeouts);
-  Clock::settle();
-  Clock::resume();
-
   Future<ReregisterExecutorMessage> reregisterExecutor =
     FUTURE_PROTOBUF(ReregisterExecutorMessage(), _, _);
 


### PR DESCRIPTION
Reverts apache/mesos#433

I'll shortly merge a better fix cancelling the timer in the slave destructor instead.