### PR TITLE
Fixed random SlaveRecoveryTest.PingTimeoutDuringRecovery test failure.

### DIFF
--- a/src/slave/slave.cpp
+++ b/src/slave/slave.cpp
@@ -255,6 +255,8 @@ Slave::~Slave()
   // TODO(benh): Shut down executors? The executor should get an "exited"
   // event and initiate a shut down itself.
 
+  Clock::cancel(pingTimer);
+
   foreachvalue (Framework* framework, frameworks) {
     delete framework;
   }


### PR DESCRIPTION
This test would randomly fail with:
```
18:16:59 3: F0501 17:16:59.192818 19175 slave.cpp:1445] Check
failed:
state == DISCONNECTED || state == RUNNING || state == TERMINATING
RECOVERING
```

The cause was that the test re-starts the slave with the same PID, which
means that timers started by the previous slave process could fire while
the new slave process was running.

In this specific case, what happened is that the previous slave's ping
timer would fire in the middle of recovery of the second slave instance,
yielding this assertion.

Fixed by cancelling the `pingTimer` in the slave destructor.

Tested by running the test in a loop, while running a CPU-intensive
workload - `stress-ng --cpu $(nproc)0` in parallel.