### PR TITLE
UPDATE: ruby version to fix bundle incompatibility.

### DIFF
--- a/support/mesos-website/Dockerfile
+++ b/support/mesos-website/Dockerfile
@@ -13,14 +13,16 @@ USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       doxygen \
-      locales \
-      ruby \
-      ruby-dev \
-      rubygems && \
+      locales && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem install bundler
+# Install ruby version manager to get a more updated ruby version                                
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - && \
+    curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - && \ 
+    curl -k -sSL https://get.rvm.io | bash -s stable --ruby=2.6.6 
+
+ENV PATH=/usr/local/rvm/rubies/ruby-2.6.6/bin:$PATH    
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
With these PR I would like to fix the website build error. The reason why I do not update to the newest ruby version is, that we will get a lot of "deprecated" error messages. So, for now it's working, but we still have an issue here.

https://ci-builds.apache.org/job/Mesos/job/Mesos-Websitebot/1326/consoleFull