### PR TITLE
Add s390x support for CI

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1465,6 +1465,7 @@ if (WIN32)
   endif ()
 else ()
   # This is for single-configuration generators such as GNU Make.
+  PATCH_CMD(PROTOBUF_PATCH_CMD protobuf-${PROTOBUF_VERSION}_s390x.patch)
   if (CMAKE_BUILD_TYPE MATCHES Debug)
     set(PROTOBUF_SUFFIX d)
   endif ()

--- a/3rdparty/Makefile.am
+++ b/3rdparty/Makefile.am
@@ -143,6 +143,7 @@ EXTRA_DIST +=			\
   $(GOOGLETEST).patch		\
   $(LIBARCHIVE).patch		\
   $(PROTOBUF).patch		\
+  ${PROTOBUF}_s390x.patch       \
   bzip2-1.0.6.patch		\
   cyrus-sasl-2.1.27rc3.patch	\
   xz-5.2.3.patch
@@ -477,13 +478,17 @@ ALL_LOCAL += $(RAPIDJSON)-stamp
 endif
 
 if WITH_BUNDLED_PROTOBUF
+# Special patch needed for s390x machines
+$(PROTOBUF)_s390x-stamp:$(PROTOBUF)-stamp
+	 test ! -e $(srcdir)/protobuf-3.5.0_s390x.patch || patch -d protobuf-3.5.0 -p1 <$(srcdir)/protobuf-3.5.0_s390x.patch
+	 touch $@
 $(PROTOBUF)/src/protoc $(PROTOBUF)/src/libprotobuf.la: $(PROTOBUF)-build-stamp
 
 # NOTE: The `--with-zlib` flag works differently between Mesos and
 # Protobuf. Protobuf uses `--with-zlib` as an on/off switch for data
 # compression instead of a path specifier for ZLib, so we need to set up
 # the `CPPFLAGS` and `LDFLAGS` if `--with-zlib=DIR` is given.
-$(PROTOBUF)-build-stamp: $(PROTOBUF)-stamp
+$(PROTOBUF)-build-stamp: $(PROTOBUF)-stamp $(PROTOBUF)_s390x-stamp
 	cd $(PROTOBUF) &&				\
 	  ./configure $(CONFIGURE_ARGS)			\
 	              CPPFLAGS="$(ZLIB_INCLUDE_FLAGS)"	\

--- a/3rdparty/protobuf-3.5.0_s390x.patch
+++ b/3rdparty/protobuf-3.5.0_s390x.patch
@@ -1,0 +1,19 @@
+diff --git a/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h b/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+index 0b0b06c..075c406 100644
+--- a/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
++++ b/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+@@ -146,6 +146,14 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
+   return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+ }
+
++inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
++                                       Atomic64 old_value,
++                                       Atomic64 new_value) {
++  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
++                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
++  return old_value;
++}
++
+ #endif // defined(__LP64__)
+
+ }  // namespace internal

--- a/support/mesos-build/ubuntu-18.04-s390x.dockerfile
+++ b/support/mesos-build/ubuntu-18.04-s390x.dockerfile
@@ -1,0 +1,61 @@
+FROM s390x/ubuntu:18.04
+
+# Install dependencies.
+RUN apt-get update && \
+    apt-get install -qy \
+      autoconf \
+      bzip2 \
+      build-essential \
+      clang \
+      curl \
+      git \
+      iputils-ping \
+      libapr1-dev \
+      libcurl4-nss-dev \
+      libev-dev \
+      libevent-dev \
+      libsasl2-dev \
+      libssl-dev \
+      libsvn-dev \
+      libtool \
+      maven \
+      openjdk-8-jdk \
+      python-dev \
+      python-six \
+      sed \
+      vim cmake \
+      software-properties-common \
+      zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+#RUN apt remove -y openjdk-11-jre-headless
+
+# Install Python 3.6.
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -qy \
+      python3.6 \
+      python3.6-dev \
+      python3.6-distutils \
+      python3.6-venv && \
+    add-apt-repository --remove -y ppa:deadsnakes/ppa && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+# Use update-alternatives to set python3.6 as python3.
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+
+# Install pip for Python 3.6.
+RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-s390x
+ENV JAVA_TOOL_OPTIONS='-Xmx2048M'
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+# Add an unprivileged user.
+RUN adduser --disabled-password --gecos '' mesos
+USER mesos
+
+COPY ["entrypoint.sh", "entrypoint.sh"]
+CMD ["./entrypoint.sh"]


### PR DESCRIPTION
Added support for **s390x** architecture by doing below mentioned changes : 

- Added a new protobuf **patch** to support s390x builds.
- Updated grpc from 1.10.0 to **1.11.0** as the newer version has support for s390x(big-endian) machines.
- **Migrated** changes from grpc-1.10.0.patch to grpc-1.11.0.patch.

grpc 1.11.0 tar.gz has been created using below commands:

**_git clone -b v1.11.0 https://github.com/grpc/grpc.git grpc-1.11.0
cd grpc-1.11.0/
git submodule update --init third_party/cares
cd ..
tar zcf grpc-1.11.0.tar.gz --exclude .git grpc-1.11.0_**

Also, **ubuntu-18.04-s390x.dockerfile** has been provided so that it can be used by Mesos CI to verify s390x builds.

We have run **mesos-build.sh**(which is also used by Mesos CI) and its passing for below configuration : 
 **_BUILDTOOL=(cmake / autotools)
 COMPILER=gcc
 CONFIGURATION="--verbose --disable-libtool-wrappers --disable-parallel-test-execution"
 ENVIRONMENT="GLOG_v=1 MESOS_VERBOSE=1 MESOS_TEST_AWAIT_TIMEOUT=60secs"_**

Note : Only one test case _DockerFetcherPluginTest.INTERNET_CURL_FetchBlob_ is failing for both intel(amd64) and s390x as its referring to a private registry **registry-1.docker.io**, so this test case should pass when it gets run from Mesos CI.

CI logs : 
Autotools : [ci_autotools_gcc_s390x.zip](https://github.com/apache/mesos/files/10041338/ci_autotools_gcc_s390x.zip)
Cmake : [ci_cmake_gcc_s390x.zip](https://github.com/apache/mesos/files/10041341/ci_cmake_gcc_s390x.zip)

As per https://issues.apache.org/jira/browse/INFRA-21433, we have provided apache **four** s390x nodes, hence, same nodes can be used to enable Apache Mesos CI as well.