### PR TITLE
Expose setmntent error reason in MountTable::read.

### DIFF
--- a/src/linux/fs.cpp
+++ b/src/linux/fs.cpp
@@ -424,7 +424,7 @@ Try<MountTable> MountTable::read(const string& path)
 
   FILE* file = ::setmntent(path.c_str(), "r");
   if (file == nullptr) {
-    return Error("Failed to open '" + path + "'");
+    return ErrnoError("Failed to open '" + path + "'");
   }
 
   while (true) {


### PR DESCRIPTION
This function is documented to set errno when it fails, but we're not exposing it.