### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries

### DIFF
--- a/src/slave/containerizer/mesos/isolators/gpu/volume.cpp
+++ b/src/slave/containerizer/mesos/isolators/gpu/volume.cpp
@@ -101,6 +101,7 @@ static constexpr const char* LIBRARIES[] = {
 
   "libnvidia-ml.so",         // Management library.
   "libnvidia-cfg.so",        // GPU configuration.
+  "libnvidia-gpucomp.so",    // GPU compiler, shared by 'Compute' and 'Graphics'
 
   // -------- Compute --------
 


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.