### PR TITLE
Added ECN configuration copying from the host to the container.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -1868,6 +1868,8 @@ Try<Isolator*> PortMappingIsolatorProcess::create(const Flags& flags)
   // configurations inside a container. Therefore, we need to set them
   // in the container to match that on the host.
   procs.insert("/proc/sys/net/core/somaxconn");
+  procs.insert("/proc/sys/net/ipv4/tcp_ecn");
+  procs.insert("/proc/sys/net/ipv4/tcp_ecn_fallback");
 
   // As of kernel 3.10, the following configurations are shared
   // between host and containers, and therefore are not required to be


### PR DESCRIPTION
The kernel uses default values for these options inside a network namespace. They need to be set inside the container to match those on the host.