### PR TITLE
Fixed CniIsolatorTest.ROOT_DynamicAddDelofCniConfig test.

### DIFF
--- a/src/tests/containerizer/cni_isolator_tests.cpp
+++ b/src/tests/containerizer/cni_isolator_tests.cpp
@@ -1043,7 +1043,7 @@ TEST_F(CniIsolatorTest, ROOT_DynamicAddDelofCniConfig)
   ASSERT_SOME(master);
 
   slave::Flags slaveFlags = CreateSlaveFlags();
-
+  slaveFlags.isolation = "network/cni";
   slaveFlags.network_cni_plugins_dir = cniPluginDir;
   slaveFlags.network_cni_config_dir = cniConfigDir;
 


### PR DESCRIPTION
The network/cni isolator was not used in the test because it was not enabled in the agent flags.