### PR TITLE
Fixed tests in PortMappingMesosTest suite.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1819,6 +1819,12 @@ message ResourceStatistics {
   // Total memory + swap usage. This is set if swap is enabled.
   optional uint64 mem_total_memsw_bytes = 37;
 
+  // Current kernel memory allocation.
+  optional uint64 mem_kmem_usage_bytes = 52;
+
+  // Current TCP buf memory allocation.
+  optional uint64 mem_kmem_tcp_usage_bytes = 53;
+
   // Hard memory limit.
   optional uint64 mem_limit_bytes = 6;
 

--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1878,6 +1878,10 @@ message ResourceStatistics {
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
 
+  optional uint64 net_tx_rate_limit = 45;
+  optional uint64 net_tx_burst_rate_limit = 46;
+  optional uint64 net_tx_burst_size = 47;
+
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.
   optional double net_tcp_rtt_microsecs_p50 = 22;

--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1884,9 +1884,9 @@ message ResourceStatistics {
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
 
-  optional uint64 net_tx_rate_limit = 45;
-  optional uint64 net_tx_burst_rate_limit = 46;
-  optional uint64 net_tx_burst_size = 47;
+  optional uint64 net_tx_rate_limit = 46;
+  optional uint64 net_tx_burst_rate_limit = 47;
+  optional uint64 net_tx_burst_size = 48;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1783,6 +1783,12 @@ message ResourceStatistics {
   // Total memory + swap usage. This is set if swap is enabled.
   optional uint64 mem_total_memsw_bytes = 37;
 
+  // Current kernel memory allocation.
+  optional uint64 mem_kmem_usage_bytes = 52;
+
+  // Current TCP buf memory allocation.
+  optional uint64 mem_kmem_tcp_usage_bytes = 53;
+
   // Hard memory limit.
   optional uint64 mem_limit_bytes = 6;
 

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1847,6 +1847,10 @@ message ResourceStatistics {
   optional uint64 net_tx_bytes = 19;
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
+  
+  optional uint64 net_tx_rate_limit = 46;
+  optional uint64 net_tx_burst_rate_limit = 47;
+  optional uint64 net_tx_burst_size = 48;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/src/common/values.cpp
+++ b/src/common/values.cpp
@@ -732,12 +732,24 @@ Try<Value> parse(const string& text)
     } else if (index == string::npos) {
       Try<double> value_ = numify<double>(temp);
       if (!value_.isError()) {
-        Option<Error> error =
-          common::validation::validateInputScalarValue(*value_);
-        if (error.isSome()) {
-          return Error("Invalid scalar value '" + temp + "':" + error->message);
+        // Check if this is a floating point value that we can work
+        // with. If not, we will handle it as text.
+        switch (std::fpclassify(value_.get())) {
+          case FP_INFINITE:
+          case FP_NAN:
+            value_ = Error("Unsupported floating point value");
+            break;
+          case FP_NORMAL:
+            if (value_.get() < 0) {
+              value_ = Error("Negative values not supported");
+            }
+            break;
+          case FP_SUBNORMAL:
+            return Error("Subnormal values not supported");
         }
+      }
 
+      if (!value_.isError()) {
         // This is a scalar.
         Value::Scalar* scalar = value.mutable_scalar();
         value.set_type(Value::SCALAR);

--- a/src/linux/cgroups.cpp
+++ b/src/linux/cgroups.cpp
@@ -2466,6 +2466,59 @@ Try<Bytes> max_usage_in_bytes(const string& hierarchy, const string& cgroup)
 }
 
 
+Result<Bytes> kmem_usage_in_bytes(const string& hierarchy, const string& cgroup)
+{
+  Try<bool> exists = cgroups::exists(
+      hierarchy, cgroup, "memory.kmem.usage_in_bytes");
+
+  if (exists.isError()) {
+    return Error(
+        "Could not check for existence of 'memory.kmem.usage_in_bytes': " +
+        exists.error());
+  }
+
+  if (!exists.get()) {
+    return None();
+  }
+
+  Try<string> read = cgroups::read(
+      hierarchy, cgroup, "memory.kmem.usage_in_bytes");
+
+  if (read.isError()) {
+    return Error(read.error());
+  }
+
+  return Bytes::parse(strings::trim(read.get()) + "B");
+}
+
+
+Result<Bytes> kmem_tcp_usage_in_bytes(
+    const string& hierarchy, const string& cgroup)
+{
+  Try<bool> exists = cgroups::exists(
+      hierarchy, cgroup, "memory.kmem.tcp.usage_in_bytes");
+
+  if (exists.isError()) {
+    return Error(
+      "Could not check for existence of 'memory.kmem.tcp.usage_in_bytes': " +
+      exists.error());
+  }
+
+  if (!exists.get()) {
+    return None();
+  }
+
+  Try<string> read = cgroups::read(
+      hierarchy, cgroup, "memory.kmem.tcp.usage_in_bytes");
+
+  if (read.isError()) {
+    return Error(read.error());
+  }
+
+  return Bytes::parse(strings::trim(read.get()) + "B");
+}
+
+
 namespace oom {
 
 Future<Nothing> listen(const string& hierarchy, const string& cgroup)

--- a/src/linux/cgroups.hpp
+++ b/src/linux/cgroups.hpp
@@ -821,6 +821,20 @@ Try<Bytes> max_usage_in_bytes(
     const std::string& cgroup);
 
 
+// Returns the memory usage from memory.kmem.usage_in_bytes. Returns
+// none if memory.kmem.usage_in_bytes is not supported.
+Result<Bytes> kmem_usage_in_bytes(
+    const std::string& hierarchy,
+    const std::string& cgroup);
+
+
+// Returns the memory usage from memory.kmem.tcp.usage_in_bytes. Returns
+// none if memory.kmem.tcp.usage_in_bytes is not supported.
+Result<Bytes> kmem_tcp_usage_in_bytes(
+    const std::string& hierarchy,
+    const std::string& cgroup);
+
+
 // Out-of-memory (OOM) controls.
 namespace oom {
 

--- a/src/slave/containerizer/mesos/isolators/cgroups/subsystems/memory.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups/subsystems/memory.cpp
@@ -460,6 +460,26 @@ Future<ResourceStatistics> MemorySubsystemProcess::usage(
 
   result.set_mem_total_bytes(usage->bytes());
 
+  Result<Bytes> kmem_usage = cgroups::memory::kmem_usage_in_bytes(
+      hierarchy, cgroup);
+
+  if (kmem_usage.isError()) {
+    return Failure("Failed to parse 'memory.kmem.usage_in_bytes': " +
+                   kmem_usage.error());
+  } else if (kmem_usage.isSome()) {
+    result.set_mem_kmem_usage_bytes(kmem_usage.get().bytes());
+  }
+
+  Result<Bytes> kmem_tcp_usage = cgroups::memory::kmem_tcp_usage_in_bytes(
+      hierarchy, cgroup);
+
+  if (kmem_tcp_usage.isError()) {
+    return Failure("Failed to parse 'memory.kmem.tcp.usage_in_bytes': " +
+                   kmem_tcp_usage.error());
+  } else if (kmem_tcp_usage.isSome()) {
+    result.set_mem_kmem_tcp_usage_bytes(kmem_tcp_usage.get().bytes());
+  }
+
   if (flags.cgroups_limit_swap) {
     Try<Bytes> usage = cgroups::memory::memsw_usage_in_bytes(hierarchy, cgroup);
 

--- a/src/slave/containerizer/mesos/isolators/network/helper.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/helper.cpp
@@ -29,5 +29,6 @@ int main(int argc, char** argv)
       argc,
       argv,
       new PortMappingUpdate(),
-      new PortMappingStatistics());
+      new PortMappingStatistics(),
+      new PortMappingHTBConfig());
 }

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -2116,6 +2116,8 @@ Try<Isolator*> PortMappingIsolatorProcess::create(const Flags& flags)
   // configurations inside a container. Therefore, we need to set them
   // in the container to match that on the host.
   procs.insert("/proc/sys/net/core/somaxconn");
+  procs.insert("/proc/sys/net/ipv4/tcp_ecn");
+  procs.insert("/proc/sys/net/ipv4/tcp_ecn_fallback");
 
   // As of kernel 3.10, the following configurations are shared
   // between host and containers, and therefore are not required to be

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1226,6 +1226,35 @@ mesos::internal::slave::Flags::Flags()
       "This flag uses the Bytes type (defined in stout) and is used by\n"
       "the `network/port_mapping` isolator.");
 
+  add(&Flags::egress_rate_per_cpu,
+      "egress_rate_per_cpu",
+      "Scale the limit of egress traffic for each container by\n"
+      "egress_rate_per_cpu Bytes/s for each whole unit of CPU resource,\n"
+      "i.e., floor(CPU), subject to the values of the\n"
+      "minimum_egress_rate_limit and maximum_egress_rate_limit flags."
+      "This flag is used by the `network/port_mapping` isolator,");
+
+  add(&Flags::minimum_egress_rate_limit,
+      "minimum_egress_rate_limit",
+      "Minimum limit of the egress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::maximum_egress_rate_limit,
+      "maximum_egress_rate_limit",
+      "Maximum limit of the egress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::egress_ceil_limit,
+      "egress_ceil_limit",
+      "Additional ceil rate in Bytes/s that containers can burst up to\n"
+      "'egress_burst' bytes at."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::egress_burst,
+      "egress_burst",
+      "Amount of data in Bytes that can sent at the higher ceil rate."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
   add(&Flags::egress_unique_flow_per_container,
       "egress_unique_flow_per_container",
       "Whether to assign an individual flow for each container for the\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -153,6 +153,11 @@ public:
   Option<std::string> eth0_name;
   Option<std::string> lo_name;
   Option<Bytes> egress_rate_limit_per_container;
+  Option<Bytes> egress_rate_per_cpu;
+  Option<Bytes> minimum_egress_rate_limit;
+  Option<Bytes> maximum_egress_rate_limit;
+  Option<Bytes> egress_ceil_limit;
+  Option<Bytes> egress_burst;
   bool egress_unique_flow_per_container;
   std::string egress_flow_classifier_parent;
   bool network_enable_socket_statistics_summary;

--- a/src/slave/main.cpp
+++ b/src/slave/main.cpp
@@ -134,6 +134,18 @@ using std::string;
 using std::vector;
 
 
+#ifdef ENABLE_JEMALLOC_ALLOCATOR
+// Reduce the number of arenas jemalloc uses. On multi-core systems
+// jemalloc creates multiple allocation arenas to reduce lock
+// contention between threads using a single arena. The default high
+// number of arenas (nproc*4) causes high RSS for the agent use case.
+// The new number was selected pretty much arbitrarily. It helped
+// reduce the agent's RSS (better than 8, same as 2) and existing
+// benchmarks didn't reveal any performance hits caused by it.
+const char* malloc_conf = "narenas:4";
+#endif
+
+
 #ifdef __linux__
 // Move the slave into its own cgroup for each of the specified
 // subsystems.

--- a/src/tests/containerizer/cgroups_isolator_tests.cpp
+++ b/src/tests/containerizer/cgroups_isolator_tests.cpp
@@ -2947,7 +2947,8 @@ TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_AgentRecoveryWithNewCgroupSubsystems)
 
 // This test verifies the container-specific cgroups are correctly mounted
 // inside the nested container.
-TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_NestedContainerSpecificCgroupsMount)
+TEST_F(CgroupsIsolatorTest,
+       ROOT_CGROUPS_INTERNET_NestedContainerSpecificCgroupsMount)
 {
   // Disable AuthN on the agent.
   slave::Flags flags = CreateSlaveFlags();
@@ -3057,7 +3058,8 @@ TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_NestedContainerSpecificCgroupsMount)
 
 // This test verifies the container-specific cgroups are correctly mounted for
 // the command task.
-TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_CommandTaskSpecificCgroupsMount)
+TEST_F(CgroupsIsolatorTest,
+       ROOT_CGROUPS_INTERNET_CommandTaskSpecificCgroupsMount)
 {
   Try<Owned<cluster::Master>> master = StartMaster();
   ASSERT_SOME(master);

--- a/src/tests/containerizer/cgroups_isolator_tests.cpp
+++ b/src/tests/containerizer/cgroups_isolator_tests.cpp
@@ -2317,6 +2317,7 @@ TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_MemoryForward)
   AWAIT_READY(usage);
 
   EXPECT_FALSE(usage->has_mem_total_bytes());
+  EXPECT_FALSE(usage->has_mem_kmem_usage_bytes());
 
   // Start a new container which will start reporting memory statistics.
   TaskInfo task2 = createTask(offers2.get()[0], "sleep 1000");
@@ -2353,6 +2354,17 @@ TEST_F(CgroupsIsolatorTest, ROOT_CGROUPS_MemoryForward)
   AWAIT_READY(usage);
 
   EXPECT_TRUE(usage->has_mem_total_bytes());
+
+  Result<string> hierarchy = cgroups::hierarchy("memory");
+  ASSERT_SOME(hierarchy);
+
+  Try<bool> exists = cgroups::exists(
+      hierarchy.get(), "memory.kmem.usage_in_bytes");
+  ASSERT_SOME(exists);
+
+  if (exists.get()) {
+    EXPECT_TRUE(usage->has_mem_kmem_usage_bytes());
+  }
 
   driver.stop();
   driver.join();

--- a/src/tests/containerizer/cni_isolator_tests.cpp
+++ b/src/tests/containerizer/cni_isolator_tests.cpp
@@ -1043,7 +1043,7 @@ TEST_F(CniIsolatorTest, ROOT_DynamicAddDelofCniConfig)
   ASSERT_SOME(master);
 
   slave::Flags slaveFlags = CreateSlaveFlags();
-
+  slaveFlags.isolation = "network/cni";
   slaveFlags.network_cni_plugins_dir = cniPluginDir;
   slaveFlags.network_cni_config_dir = cniConfigDir;
 

--- a/src/tests/containerizer/isolator_tests.cpp
+++ b/src/tests/containerizer/isolator_tests.cpp
@@ -274,7 +274,7 @@ TEST_F(NamespacesIsolatorTest, ROOT_SharePidNamespaceWhenDisallow)
 // namespace and nested container will share the IPC namespace with its
 // parent container. If the container does not have its own rootfs, it
 // will share agent's /dev/shm, otherwise it will have its own /dev/shm.
-TEST_F(NamespacesIsolatorTest, ROOT_IPCNamespaceWithIPCModeUnset)
+TEST_F(NamespacesIsolatorTest, ROOT_INTERNET_IPCNamespaceWithIPCModeUnset)
 {
   Try<Owned<MesosContainerizer>> containerizer =
     createContainerizer("filesystem/linux,namespaces/ipc");
@@ -411,7 +411,8 @@ TEST_F(NamespacesIsolatorTest, ROOT_IPCNamespaceWithIPCModeUnset)
 // containers will share IPC namespace with agent, and if the container
 // does not have its own rootfs, it will also share agent's /dev/shm,
 // otherwise it will have its own /dev/shm.
-TEST_F(NamespacesIsolatorTest, ROOT_IPCNamespaceWithIPCIsolatorDisabled)
+TEST_F(NamespacesIsolatorTest,
+       ROOT_INTERNET_IPCNamespaceWithIPCIsolatorDisabled)
 {
   Try<Owned<MesosContainerizer>> containerizer =
     createContainerizer("filesystem/linux");
@@ -525,7 +526,7 @@ TEST_F(NamespacesIsolatorTest, ROOT_IPCNamespaceWithIPCIsolatorDisabled)
 // have its own IPC namespace and /dev/shm, and it can share IPC namespace
 // and /dev/shm with its child containers, grandchild containers and debug
 // containers.
-TEST_F(NamespacesIsolatorTest, ROOT_ShareIPCNamespace)
+TEST_F(NamespacesIsolatorTest, ROOT_INTERNET_ShareIPCNamespace)
 {
   Try<Owned<MesosContainerizer>> containerizer =
     createContainerizer("filesystem/linux,namespaces/ipc");
@@ -924,7 +925,7 @@ TEST_F(NamespacesIsolatorTest, ROOT_PrivateIPCNamespace)
 
 // This test verifies that top-level container and nested
 // containers can share agent's IPC namespace and /dev/shm.
-TEST_F(NamespacesIsolatorTest, ROOT_ShareAgentIPCNamespace)
+TEST_F(NamespacesIsolatorTest, ROOT_INTERNET_ShareAgentIPCNamespace)
 {
   Try<Owned<MesosContainerizer>> containerizer =
     createContainerizer("filesystem/linux,namespaces/ipc");

--- a/src/tests/containerizer/memory_isolator_tests.cpp
+++ b/src/tests/containerizer/memory_isolator_tests.cpp
@@ -150,6 +150,22 @@ TEST_P(MemoryIsolatorTest, ROOT_MemUsage)
   EXPECT_LT(0u, usage->mem_rss_bytes());
 #endif // __WINDOWS__
 
+  // Metrics for kmem are only enabled with memory isolation.
+  if (GetParam() == "cgroups/mem") {
+    Result<std::string> hierarchy = cgroups::hierarchy("memory");
+    ASSERT_SOME(hierarchy);
+
+    Try<bool> kmemExists = cgroups::exists(
+        hierarchy.get(), "memory.kmem.usage_in_bytes");
+    ASSERT_SOME(kmemExists);
+
+    if (kmemExists.get()) {
+      // We can assume more than 4096 bytes here, since a kernel page size is
+      // 4kB and we are allocating at least one.
+      ASSERT_LT(4096u, usage.get().mem_kmem_usage_bytes());
+    }
+  }
+
   driver.stop();
   driver.join();
 }

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1506,6 +1506,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 
   // Use a very small egress limit.
   flags.egress_rate_limit_per_container = rate;
+  flags.minimum_egress_rate_limit = 0;
 
   Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
   ASSERT_SOME(isolator);
@@ -1625,6 +1626,116 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 }
 
 
+TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPU)
+{
+  flags.egress_rate_limit_per_container = None();
+
+  const Bytes egressRatePerCpu = 1000;
+  flags.egress_rate_per_cpu = egressRatePerCpu;
+
+  const Bytes minRate = 2000;
+  flags.minimum_egress_rate_limit = minRate;
+
+  const Bytes maxRate = 4000;
+  flags.maximum_egress_rate_limit = maxRate;
+
+  // CPU low enough for scaled network egress to be increased to
+  // min limit: 1 * 1000 < 2000 ==> egress is 2000.
+  Try<Resources> lowCpu = Resources::parse("cpus:1;mem:1024;disk:1024");
+  ASSERT_SOME(lowCpu);
+
+  // CPU sufficient to be in linear scaling region, greater than min
+  // and less than max: 2000 < 3.1 * 1000 < 4000.
+  Try<Resources> linearCpu = Resources::parse("cpus:3.1;mem:1024;disk:1024");
+  ASSERT_SOME(linearCpu);
+
+  // CPU high enough for scaled network egress to be reduced to the
+  // max limit: 5 * 1000 > 4000.
+  Try<Resources> highCpu = Resources::parse("cpus:5;mem:1024;disk:1024");
+  ASSERT_SOME(highCpu);
+
+  Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
+  ASSERT_SOME(isolator);
+
+  Try<Launcher*> launcher = LinuxLauncher::create(flags);
+  ASSERT_SOME(launcher);
+
+  ExecutorInfo executorInfo;
+  executorInfo.mutable_resources()->CopyFrom(lowCpu.get());
+
+  ContainerID containerId1;
+  containerId1.set_value(id::UUID::random().toString());
+
+  ContainerConfig containerConfig1;
+  containerConfig1.mutable_executor_info()->CopyFrom(executorInfo);
+
+  Future<Option<ContainerLaunchInfo>> launchInfo1 =
+    isolator.get()->prepare(containerId1, containerConfig1);
+  AWAIT_READY(launchInfo1);
+  ASSERT_SOME(launchInfo1.get());
+  ASSERT_EQ(1, launchInfo1.get()->pre_exec_commands().size());
+
+  int pipes[2];
+  ASSERT_NE(-1, ::pipe(pipes));
+
+  Try<pid_t> pid = launchHelper(
+      launcher.get(),
+      pipes,
+      containerId1,
+      "touch " + container1Ready + " && sleep 1000",
+      launchInfo1.get());
+  ASSERT_SOME(pid);
+
+  // Reap the forked child.
+  Future<Option<int>> status = process::reap(pid.get());
+
+  // Continue in the parent.
+  ::close(pipes[0]);
+
+  // Isolate the forked child.
+  AWAIT_READY(isolator.get()->isolate(containerId1, pid.get()));
+
+  // Signal forked child to continue.
+  char dummy;
+  ASSERT_LT(0, ::write(pipes[1], &dummy, sizeof(dummy)));
+  ::close(pipes[1]);
+
+  // Wait for command to start to ensure all pre-exec scripts have
+  // executed.
+  ASSERT_TRUE(waitForFileCreation(container1Ready));
+
+  Result<htb::cls::Config> config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(minRate, config->rate);
+
+  // Increase CPU to get to linear scaling.
+  Future<Nothing> update = isolator.get()->update(
+      containerId1,
+      linearCpu.get());
+  AWAIT_READY(update);
+
+  config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(
+      egressRatePerCpu.bytes() * floor(linearCpu.get().cpus().get()),
+      config->rate);
+
+  // Increase CPU further to hit maximum limit.
+  update = isolator.get()->update(
+      containerId1,
+      highCpu.get());
+  AWAIT_READY(update);
+
+  config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(maxRate, config->rate);
+
+  // Kill the container
+  AWAIT_READY(launcher.get()->destroy(containerId1));
+  AWAIT_READY(isolator.get()->cleanup(containerId1));
+}
+
+
 bool HasTCPSocketsCount(const ResourceStatistics& statistics)
 {
   return statistics.has_net_tcp_active_connections() &&
@@ -1665,6 +1776,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_PortMappingStatistics)
 
   // Use a very small egress limit.
   flags.egress_rate_limit_per_container = rate;
+  flags.minimum_egress_rate_limit = 0;
   flags.network_enable_socket_statistics_summary = true;
   flags.network_enable_socket_statistics_details = true;
   flags.network_enable_snmp_statistics = true;

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -480,6 +480,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_ContainerToContainerTCP)
 
   ContainerConfig containerConfig1;
   containerConfig1.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig1.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig1.set_directory(dir1.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo1 =
@@ -549,6 +550,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_ContainerToContainerTCP)
 
   ContainerConfig containerConfig2;
   containerConfig2.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig2.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig2.set_directory(dir2.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo2 =
@@ -643,6 +645,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_ContainerToContainerUDP)
 
   ContainerConfig containerConfig1;
   containerConfig1.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig1.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig1.set_directory(dir1.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo1 =
@@ -712,6 +715,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_ContainerToContainerUDP)
 
   ContainerConfig containerConfig2;
   containerConfig2.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig2.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig2.set_directory(dir2.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo2 =
@@ -808,6 +812,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_HostToContainerUDP)
 
   ContainerConfig containerConfig;
   containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig.set_directory(dir.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo =
@@ -870,22 +875,23 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_HostToContainerUDP)
   command2 << "printf hello1 | nc -w1 -u localhost " << validPort;
   ASSERT_SOME(os::shell(command2.str()));
 
-  // Send to 'localhost' and 'invalidPort'. The command should return
-  // successfully because UDP is stateless but no data could be sent.
+  // Send to 'localhost' and 'invalidPort'. Some 'nc' implementations
+  // (e.g. Ncat from Nmap) return an error when they see ECONNREFUSED
+  // on a datagram socket, so we don't check the exit code when
+  // sending to 'invalidPort'.
   ostringstream command3;
   command3 << "printf hello2 | nc -w1 -u localhost " << invalidPort;
-  ASSERT_SOME(os::shell(command3.str()));
+  os::shell(command3.str());
 
   // Send to 'public IP' and 'port'.
   ostringstream command4;
   command4 << "printf hello3 | nc -w1 -u " << hostIP << " " << validPort;
   ASSERT_SOME(os::shell(command4.str()));
 
-  // Send to 'public IP' and 'invalidPort'. The command should return
-  // successfully because UDP is stateless but no data could be sent.
+  // Send to 'public IP' and 'invalidPort'.
   ostringstream command5;
   command5 << "printf hello4 | nc -w1 -u " << hostIP << " " << invalidPort;
-  ASSERT_SOME(os::shell(command5.str()));
+  os::shell(command5.str());
 
   EXPECT_SOME_EQ("hello1", os::read(trafficViaLoopback));
   EXPECT_SOME_EQ("hello3", os::read(trafficViaPublic));
@@ -926,6 +932,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_HostToContainerTCP)
 
   ContainerConfig containerConfig;
   containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig.set_directory(dir.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo =
@@ -1198,7 +1205,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_ContainerICMPInternal)
 
 // Test the scenario where a container issues ARP requests to
 // external hosts.
-TEST_F(PortMappingIsolatorTest, ROOT_ContainerARPExternal)
+TEST_F(PortMappingIsolatorTest, DISABLED_ROOT_ContainerARPExternal)
 {
   // TODO(chzhcn): Even though this is unlikely, consider a better
   // way to get external servers.
@@ -1229,6 +1236,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_ContainerARPExternal)
 
   ContainerConfig containerConfig;
   containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig.set_directory(dir.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo =
@@ -1537,6 +1545,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 
   ContainerConfig containerConfig;
   containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig.set_directory(dir.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo =
@@ -1812,6 +1821,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_PortMappingStatistics)
 
   ContainerConfig containerConfig;
   containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
   containerConfig.set_directory(dir.get());
 
   Future<Option<ContainerLaunchInfo>> launchInfo =
@@ -2116,7 +2126,8 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedContainers)
       Resources::parse("cpus:1;mem:512").get(),
       "sleep 1000");
 
-  EXPECT_CALL(sched, statusUpdate(_, _));
+  EXPECT_CALL(sched, statusUpdate(_, _))
+    .WillRepeatedly(Return());
 
   Future<Nothing> _statusUpdateAcknowledgement1 =
     FUTURE_DISPATCH(_, &Slave::_statusUpdateAcknowledgement);
@@ -2148,14 +2159,10 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedContainers)
   slave = StartSlave(detector.get(), containerizer.get(), slaveFlags);
   ASSERT_SOME(slave);
 
-  Clock::pause();
-
   AWAIT_READY(_recover1);
-
-  Clock::settle(); // Wait for slave to schedule reregister timeout.
-  Clock::advance(slaveFlags.executor_reregistration_timeout);
-
   AWAIT_READY(slaveReregisteredMessage1);
+
+  Clock::pause();
 
   Clock::settle(); // Make sure an allocation is scheduled.
   Clock::advance(masterFlags.allocation_interval);
@@ -2170,7 +2177,8 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedContainers)
   // Start a long running task using the network isolator.
   TaskInfo task2 = createTask(offer2, "sleep 1000");
 
-  EXPECT_CALL(sched, statusUpdate(_, _));
+  EXPECT_CALL(sched, statusUpdate(_, _))
+    .WillRepeatedly(Return());
 
   Future<Nothing> _statusUpdateAcknowledgement2 =
     FUTURE_DISPATCH(_, &Slave::_statusUpdateAcknowledgement);
@@ -2197,16 +2205,8 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedContainers)
   slave = StartSlave(detector.get(), containerizer.get(), slaveFlags);
   ASSERT_SOME(slave);
 
-  Clock::pause();
-
   AWAIT_READY(_recover2);
-
-  Clock::settle(); // Wait for slave to schedule reregister timeout.
-  Clock::advance(slaveFlags.executor_reregistration_timeout);
-
   AWAIT_READY(slaveReregisteredMessage2);
-
-  Clock::resume();
 
   // Ensure that both containers (with and without network isolation)
   // were recovered.
@@ -2533,7 +2533,7 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedKnownAndUnKnownOrphans)
   ASSERT_EQ(TASK_STARTING, status1->state());
 
   AWAIT_READY(status4);
-  ASSERT_EQ(TASK_RUNNING, status2->state());
+  ASSERT_EQ(TASK_RUNNING, status4->state());
 
   // Obtain the container IDs.
   Future<hashset<ContainerID>> containers = containerizer->containers();
@@ -2562,6 +2562,10 @@ TEST_F(PortMappingMesosTest, ROOT_CGROUPS_RecoverMixedKnownAndUnKnownOrphans)
 
   Future<SlaveRegisteredMessage> slaveRegisteredMessage =
     FUTURE_PROTOBUF(SlaveRegisteredMessage(), _, _);
+
+  // Destroy the old containerizer first so that it won't remove new
+  // containerizer's metrics.
+  containerizer.reset();
 
   _containerizer = MesosContainerizer::create(flags, true, &fetcher);
   ASSERT_SOME(_containerizer);

--- a/src/tests/values_tests.cpp
+++ b/src/tests/values_tests.cpp
@@ -73,6 +73,37 @@ TEST(ValuesTest, ValidInput)
   ASSERT_SOME(result4);
   ASSERT_EQ(Value::TEXT, result4->type());
   ASSERT_EQ("123abc,s", result4->text().value());
+
+  // Test parsing unsupported scalar values.
+  Try<Value> result5 = parse("inf");
+  ASSERT_SOME(result5);
+  ASSERT_EQ(Value::TEXT, result5->type());
+  ASSERT_EQ("inf", result5->text().value());
+
+  Try<Value> result6 = parse("-inf");
+  ASSERT_SOME(result6);
+  ASSERT_EQ(Value::TEXT, result6->type());
+  ASSERT_EQ("-inf", result6->text().value());
+
+  Try<Value> result7 = parse("infinity");
+  ASSERT_SOME(result7);
+  ASSERT_EQ(Value::TEXT, result7->type());
+  ASSERT_EQ("infinity", result7->text().value());
+
+  Try<Value> result8 = parse("-infinity");
+  ASSERT_SOME(result8);
+  ASSERT_EQ(Value::TEXT, result8->type());
+  ASSERT_EQ("-infinity", result8->text().value());
+
+  Try<Value> result9 = parse("nan");
+  ASSERT_SOME(result9);
+  ASSERT_EQ(Value::TEXT, result9->type());
+  ASSERT_EQ("nan", result9->text().value());
+
+  Try<Value> result10 = parse("-nan");
+  ASSERT_SOME(result10);
+  ASSERT_EQ(Value::TEXT, result10->type());
+  ASSERT_EQ("-nan", result10->text().value());
 }
 
 
@@ -90,14 +121,9 @@ TEST(ValuesTest, InvalidInput)
   // Test when giving empty string.
   EXPECT_ERROR(parse("  "));
 
-  EXPECT_ERROR(parse("nan"));
-  EXPECT_ERROR(parse("-nan"));
-
-  EXPECT_ERROR(parse("inf"));
-  EXPECT_ERROR(parse("-inf"));
-
-  EXPECT_ERROR(parse("infinity"));
-  EXPECT_ERROR(parse("-infinity"));
+  // Test subnormal scalar value.
+  EXPECT_ERROR(parse("7.63918e-313"));
+  EXPECT_ERROR(parse("-7.63918e-313"));
 }
 
 


### PR DESCRIPTION
ROOT_NC_ContainerToContainerTCP, ROOT_NC_ContainerToContainerUDP, ROOT_NC_HostToContainerUDP, ROOT_NC_HostToContainerTCP, and ROOT_ContainerARPExternal are missing resources in ContainerConfig, which is now required after one of the upstream changes switched the isolator from using container resources specified in ExecutorInfo to using resources in ContainerConfig.

ROOT_NC_HostToContainerUDP is expecting nc to finish successfully when using invalid port. It fails with some nc implementations, e.g. Ncat from Nmap used by RHEL/CentOS, that return an error when they see ECONNREFUSED on a datagram socket.

ROOT_ContainerARPExternal tries to arping nameservers from /etc/resolv.conf. We don't have any nameservers configured in our local subnet, so we have to disable this test. This is a Twitter specific change.

ROOT_CGROUPS_RecoverMixedContainers does unnecessary clock manipulations that cause recovered task termination before its executor has a chance to re-register. It also installs a statusUpdate mock expectations that get oversaturated as they don't take TASK_STARTING update into account.

ROOT_CGROUPS_RecoverMixedKnownAndUnKnownOrphans checks a wrong status update due to a typo.