### PR TITLE
Optionally scale egress bandwidth with CPU.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1878,6 +1878,10 @@ message ResourceStatistics {
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
 
+  optional uint64 net_tx_rate_limit = 46;
+  optional uint64 net_tx_burst_rate_limit = 47;
+  optional uint64 net_tx_burst_size = 48;
+
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.
   optional double net_tcp_rtt_microsecs_p50 = 22;

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1841,6 +1841,10 @@ message ResourceStatistics {
   optional uint64 net_tx_bytes = 19;
   optional uint64 net_tx_errors = 20;
   optional uint64 net_tx_dropped = 21;
+  
+  optional uint64 net_tx_rate_limit = 46;
+  optional uint64 net_tx_burst_rate_limit = 47;
+  optional uint64 net_tx_burst_size = 48;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/src/slave/containerizer/mesos/isolators/network/helper.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/helper.cpp
@@ -29,5 +29,6 @@ int main(int argc, char** argv)
       argc,
       argv,
       new PortMappingUpdate(),
-      new PortMappingStatistics());
+      new PortMappingStatistics(),
+      new PortMappingHTBConfig());
 }

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1226,6 +1226,35 @@ mesos::internal::slave::Flags::Flags()
       "This flag uses the Bytes type (defined in stout) and is used by\n"
       "the `network/port_mapping` isolator.");
 
+  add(&Flags::egress_rate_per_cpu,
+      "egress_rate_per_cpu",
+      "Scale the limit of egress traffic for each container by\n"
+      "egress_rate_per_cpu Bytes/s for each whole unit of CPU resource,\n"
+      "i.e., floor(CPU), subject to the values of the\n"
+      "minimum_egress_rate_limit and maximum_egress_rate_limit flags."
+      "This flag is used by the `network/port_mapping` isolator,");
+
+  add(&Flags::minimum_egress_rate_limit,
+      "minimum_egress_rate_limit",
+      "Minimum limit of the egress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::maximum_egress_rate_limit,
+      "maximum_egress_rate_limit",
+      "Maximum limit of the egress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::egress_ceil_limit,
+      "egress_ceil_limit",
+      "Additional ceil rate in Bytes/s that containers can burst up to\n"
+      "'egress_burst' bytes at."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::egress_burst,
+      "egress_burst",
+      "Amount of data in Bytes that can sent at the higher ceil rate."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
   add(&Flags::egress_unique_flow_per_container,
       "egress_unique_flow_per_container",
       "Whether to assign an individual flow for each container for the\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -153,6 +153,11 @@ public:
   Option<std::string> eth0_name;
   Option<std::string> lo_name;
   Option<Bytes> egress_rate_limit_per_container;
+  Option<Bytes> egress_rate_per_cpu;
+  Option<Bytes> minimum_egress_rate_limit;
+  Option<Bytes> maximum_egress_rate_limit;
+  Option<Bytes> egress_ceil_limit;
+  Option<Bytes> egress_burst;
   bool egress_unique_flow_per_container;
   std::string egress_flow_classifier_parent;
   bool network_enable_socket_statistics_summary;

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1506,6 +1506,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 
   // Use a very small egress limit.
   flags.egress_rate_limit_per_container = rate;
+  flags.minimum_egress_rate_limit = 0;
 
   Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
   ASSERT_SOME(isolator);
@@ -1625,6 +1626,116 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 }
 
 
+TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPU)
+{
+  flags.egress_rate_limit_per_container = None();
+
+  const Bytes egressRatePerCpu = 1000;
+  flags.egress_rate_per_cpu = egressRatePerCpu;
+
+  const Bytes minRate = 2000;
+  flags.minimum_egress_rate_limit = minRate;
+
+  const Bytes maxRate = 4000;
+  flags.maximum_egress_rate_limit = maxRate;
+
+  // CPU low enough for scaled network egress to be increased to
+  // min limit: 1 * 1000 < 2000 ==> egress is 2000.
+  Try<Resources> lowCpu = Resources::parse("cpus:1;mem:1024;disk:1024");
+  ASSERT_SOME(lowCpu);
+
+  // CPU sufficient to be in linear scaling region, greater than min
+  // and less than max: 2000 < 3.1 * 1000 < 4000.
+  Try<Resources> linearCpu = Resources::parse("cpus:3.1;mem:1024;disk:1024");
+  ASSERT_SOME(linearCpu);
+
+  // CPU high enough for scaled network egress to be reduced to the
+  // max limit: 5 * 1000 > 4000.
+  Try<Resources> highCpu = Resources::parse("cpus:5;mem:1024;disk:1024");
+  ASSERT_SOME(highCpu);
+
+  Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
+  ASSERT_SOME(isolator);
+
+  Try<Launcher*> launcher = LinuxLauncher::create(flags);
+  ASSERT_SOME(launcher);
+
+  ExecutorInfo executorInfo;
+  executorInfo.mutable_resources()->CopyFrom(lowCpu.get());
+
+  ContainerID containerId1;
+  containerId1.set_value(id::UUID::random().toString());
+
+  ContainerConfig containerConfig1;
+  containerConfig1.mutable_executor_info()->CopyFrom(executorInfo);
+
+  Future<Option<ContainerLaunchInfo>> launchInfo1 =
+    isolator.get()->prepare(containerId1, containerConfig1);
+  AWAIT_READY(launchInfo1);
+  ASSERT_SOME(launchInfo1.get());
+  ASSERT_EQ(1, launchInfo1.get()->pre_exec_commands().size());
+
+  int pipes[2];
+  ASSERT_NE(-1, ::pipe(pipes));
+
+  Try<pid_t> pid = launchHelper(
+      launcher.get(),
+      pipes,
+      containerId1,
+      "touch " + container1Ready + " && sleep 1000",
+      launchInfo1.get());
+  ASSERT_SOME(pid);
+
+  // Reap the forked child.
+  Future<Option<int>> status = process::reap(pid.get());
+
+  // Continue in the parent.
+  ::close(pipes[0]);
+
+  // Isolate the forked child.
+  AWAIT_READY(isolator.get()->isolate(containerId1, pid.get()));
+
+  // Signal forked child to continue.
+  char dummy;
+  ASSERT_LT(0, ::write(pipes[1], &dummy, sizeof(dummy)));
+  ::close(pipes[1]);
+
+  // Wait for command to start to ensure all pre-exec scripts have
+  // executed.
+  ASSERT_TRUE(waitForFileCreation(container1Ready));
+
+  Result<htb::cls::Config> config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(minRate, config->rate);
+
+  // Increase CPU to get to linear scaling.
+  Future<Nothing> update = isolator.get()->update(
+      containerId1,
+      linearCpu.get());
+  AWAIT_READY(update);
+
+  config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(
+      egressRatePerCpu.bytes() * floor(linearCpu.get().cpus().get()),
+      config->rate);
+
+  // Increase CPU further to hit maximum limit.
+  update = isolator.get()->update(
+      containerId1,
+      highCpu.get());
+  AWAIT_READY(update);
+
+  config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(maxRate, config->rate);
+
+  // Kill the container
+  AWAIT_READY(launcher.get()->destroy(containerId1));
+  AWAIT_READY(isolator.get()->cleanup(containerId1));
+}
+
+
 bool HasTCPSocketsCount(const ResourceStatistics& statistics)
 {
   return statistics.has_net_tcp_active_connections() &&
@@ -1665,6 +1776,7 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_PortMappingStatistics)
 
   // Use a very small egress limit.
   flags.egress_rate_limit_per_container = rate;
+  flags.minimum_egress_rate_limit = 0;
   flags.network_enable_socket_statistics_summary = true;
   flags.network_enable_socket_statistics_details = true;
   flags.network_enable_snmp_statistics = true;


### PR DESCRIPTION
Add support to isolators/port_mapping for optionally scaling egress bandwidth with CPU and with minimum and maximum limits.