### PR TITLE
Fixed sorting in MountInfoTable::read.

### DIFF
--- a/src/tests/containerizer/fs_tests.cpp
+++ b/src/tests/containerizer/fs_tests.cpp
@@ -196,7 +196,7 @@ TEST_F(FsTest, MountInfoTableReadSorted)
 
   // Verify that all parent entries appear *before* their children.
   foreach (const MountInfoTable::Entry& entry, table->entries) {
-    if (entry.target != "/") {
+    if (entry.target != "/" && entry.parent != entry.id) {
       ASSERT_TRUE(ids.contains(entry.parent));
     }
 
@@ -225,12 +225,13 @@ TEST_F(FsTest, MountInfoTableReadSortedParentOfSelf)
   // Examine the calling process's mountinfo table.
   Try<MountInfoTable> table = MountInfoTable::read(lines);
   ASSERT_SOME(table);
+  EXPECT_EQ(table->entries.size(), strings::tokenize(lines, "\n").size());
 
   hashset<int> ids;
 
   // Verify that all parent entries appear *before* their children.
   foreach (const MountInfoTable::Entry& entry, table->entries) {
-    if (entry.target != "/") {
+    if (entry.target != "/" && entry.parent != entry.id) {
       ASSERT_TRUE(ids.contains(entry.parent));
     }
 


### PR DESCRIPTION
Current implementation of MountInfoTable sorting crashes when some parts of the mount tree are not visible in /proc/{pid}/mountinfo, which can happen, for example, in a chrooted environment. The sorter assumes that the / mount is always present and uses it as the starting node for the DFS traversal.

Additionally, this sorting algorithm loses mounts that are parents of themselves from the sorted MountInfoTable. The bug is not caught by FsTest.MountInfoTableReadSortedParentOfSelf test, so it needs to be updated as well.

The new sorting implementation supports multiple starting nodes and works in situations where the visible mount tree is disconnected. It also changes the resulting order to BFS, but that shouldn't matter because the invariant is that all parent entries appear before their child entries.