### PR TITLE
Added LevelDB compaction after replicated log truncation.

### DIFF
--- a/src/log/leveldb.hpp
+++ b/src/log/leveldb.hpp
@@ -42,10 +42,14 @@ public:
   Try<Action> read(uint64_t position) override;
 
 private:
+  void compactRange(uint64_t first, uint64_t last);
+
   leveldb::DB* db;
 
   // First position still in leveldb, used during truncation.
   Option<uint64_t> first;
+
+  bool autoCompact = true;
 };
 
 } // namespace log {


### PR DESCRIPTION
LevelDB compaction algorithm doesn't seem to work well with out key
usage pattern because the background compaction is not triggered [1].
Because of that the replicated log storage grows over time until it
consumes all disk space on the partition. As a workaround we can
manually invoke leveldb::DB::CompactRange() every time a truncation
action is persisted and some stored keys are removed. This workaround
can be turned off by setting the MESOS_LOG_AUTO_COMPACT_DISABLED=1 environment
variable.

[1] https://github.com/google/leveldb/issues/603

See MESOS-184 and https://github.com/google/leveldb/issues/603 for details.