### PR TITLE
Fixed port_mapping isolator upgrade process.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -643,7 +643,8 @@ static Try<Nothing> updateHTB(
     Try<bool> htbQdisc = htb::create(
         eth0,
         EGRESS_ROOT,
-        CONTAINER_TX_HTB_HANDLE);
+        CONTAINER_TX_HTB_HANDLE,
+        htb::DisciplineConfig(1));
     if (htbQdisc.isError()) {
       return Error("Failed to add htb class: " + htbQdisc.error());
     }


### PR DESCRIPTION
When egress rate limiting is applied to the existing container without it, the HTB qdisc is created with default class ID configured to 0 (default). Because of that egress traffic from the container misses the rate limiting class 1:1. This fixes it by setting default class ID to 1.