### PR TITLE
Renamed egress config related vars in port_mapping isolator.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -2757,7 +2757,7 @@ PortMappingIsolatorProcess::_recover(pid_t pid)
 
   // Block until we determine the container's HTB config. Ignore
   // errors here.
-  Result<htb::cls::Config> htb = recoverHTBConfig(pid, eth0, flags);
+  Result<htb::cls::Config> egressConfig = recoverHTBConfig(pid, eth0, flags);
 
   Info* info = nullptr;
 
@@ -2774,13 +2774,15 @@ PortMappingIsolatorProcess::_recover(pid_t pid)
     info = new Info(
         nonEphemeralPorts,
         Interval<uint16_t>(),
-        (htb.isSome() ? Option<htb::cls::Config>(htb.get()) : None()),
+        (egressConfig.isSome()
+         ? Option<htb::cls::Config>(egressConfig.get()) : None()),
         pid);
 
     VLOG(1) << "Recovered network isolator for container with pid " << pid
             << " non-ephemeral port ranges " << nonEphemeralPorts
             << " and egress HTB config "
-            << (htb.isSome() ? jsonify(htb.get()) : string("None"));
+            << (egressConfig.isSome()
+                ? jsonify(egressConfig.get()) : string("None"));
   } else {
     if (ephemeralPorts.intervalCount() != 1) {
       return Error("Each container should have only one ephemeral port range");
@@ -2792,14 +2794,16 @@ PortMappingIsolatorProcess::_recover(pid_t pid)
     info = new Info(
         nonEphemeralPorts,
         *ephemeralPorts.begin(),
-        htb.isSome() ? Option<htb::cls::Config>(htb.get()) : None(),
+        (egressConfig.isSome()
+         ? Option<htb::cls::Config>(egressConfig.get()) : None()),
         pid);
 
     VLOG(1) << "Recovered network isolator for container with pid " << pid
             << " non-ephemeral port ranges " << nonEphemeralPorts
             << " and ephemeral port range " << *ephemeralPorts.begin()
             << " and egress HTB config "
-            << (htb.isSome() ? jsonify(htb.get()) : string("None"));
+            << (egressConfig.isSome()
+                ? jsonify(egressConfig.get()) : string("None"));
   }
 
   if (flowId.isSome()) {
@@ -2864,7 +2868,7 @@ Future<Option<ContainerLaunchInfo>> PortMappingIsolatorProcess::prepare(
   infos[containerId] = new Info(
       nonEphemeralPorts,
       ephemeralPorts.get(),
-      htbConfig(resources));
+      egressHTBConfig(resources);
 
   LOG(INFO) << "Using non-ephemeral ports " << nonEphemeralPorts
             << " and ephemeral ports " << ephemeralPorts.get()
@@ -3333,12 +3337,12 @@ Future<Nothing> PortMappingIsolatorProcess::update(
     }
   }
 
-  Option<htb::cls::Config> htb = htbConfig(resources);
+  Option<htb::cls::Config> egressConfig = egressHTBConfig(resources);
 
   // No need to proceed if no change to the non-ephemeral ports and no
-  // change to the HTB configuration.
+  // change to the egress HTB configuration.
   if ((nonEphemeralPorts == info->nonEphemeralPorts) &&
-      (htb == info->htb)) {
+      (egressConfig == info->egressConfig)) {
     return Nothing();
   }
 
@@ -3442,15 +3446,17 @@ Future<Nothing> PortMappingIsolatorProcess::update(
   // Set the flags for updating the egress rate, if it has changed. We
   // explicitly send an empty JSON::Object if there's no config so an
   // existing class will be removed.
-  if (htb != info->htb) {
-    update.flags.htb_config = htb.isSome() ? json(htb.get()) : JSON::Object();
+  if (egressConfig != info->egressConfig) {
+    update.flags.htb_config =
+      egressConfig.isSome() ? json(egressConfig.get()) : JSON::Object();
 
-    LOG(INFO) << "Setting htb config to "
-              << (htb.isSome() ? jsonify(htb.get()) : string("None"))
+    LOG(INFO) << "Setting egress HTB config to "
+              << (egressConfig.isSome()
+                  ? jsonify(egressConfig.get()) : string("None"))
               << " for container " << containerId;
 
     // Update the egress rate limit for this container.
-    info->htb = htb;
+    info->egressConfig = egressConfig;
   }
 
   // Use the mesos-network-helper to make changes inside the
@@ -3569,14 +3575,14 @@ Future<ResourceStatistics> PortMappingIsolatorProcess::usage(
   }
 
   // Include the egress shaping limits, if applied.
-  if (info->htb.isSome()) {
-    result.set_net_tx_rate_limit(info->htb->rate);
+  if (info->egressConfig.isSome()) {
+    result.set_net_tx_rate_limit(info->egressConfig->rate);
 
-    if (info->htb->ceil.isSome()) {
-      result.set_net_tx_burst_rate_limit(info->htb->ceil.get());
+    if (info->egressConfig->ceil.isSome()) {
+      result.set_net_tx_burst_rate_limit(info->egressConfig->ceil.get());
 
-      if (info->htb->burst.isSome()) {
-        result.set_net_tx_burst_size(info->htb->burst.get());
+      if (info->egressConfig->burst.isSome()) {
+        result.set_net_tx_burst_size(info->egressConfig->burst.get());
       }
     }
   }
@@ -4309,7 +4315,7 @@ Try<Nothing> PortMappingIsolatorProcess::removeHostIPFilters(
 }
 
 
-Option<htb::cls::Config> PortMappingIsolatorProcess::htbConfig(
+Option<htb::cls::Config> PortMappingIsolatorProcess::egressHTBConfig(
     const Resources& resources) const
 {
   Bytes rate(0);
@@ -4488,20 +4494,19 @@ string PortMappingIsolatorProcess::scripts(Info* info)
   // Additionally, HTB has a simpler interface for just capping the
   // throughput. TBF requires other parameters such as 'burst' that
   // HTB already has default values for.
-  if (info->htb.isSome()) {
+  if (info->egressConfig.isSome()) {
     script << "tc qdisc add dev " << eth0 << " root handle "
            << CONTAINER_TX_HTB_HANDLE << " htb default 1\n";
     script << "tc class add dev " << eth0 << " parent "
            << CONTAINER_TX_HTB_HANDLE << " classid "
            << CONTAINER_TX_HTB_CLASS_ID << " htb rate "
-           << info->htb->rate * 8 << "bit";
-    if (info->htb->ceil.isSome()) {
+           << info->egressConfig->rate * 8 << "bit";
+    if (info->egressConfig->ceil.isSome()) {
       script << " ceil "
-             << info->htb->ceil.get() * 8 << "bit";
-      if (info->htb->burst.isSome()) {
+             << info->egressConfig->ceil.get() * 8 << "bit";
+      if (info->egressConfig->burst.isSome()) {
         // Use bytes here because tc command borks at bits.
-        script << " burst "
-               << info->htb->burst.get() << "b";
+        script << " burst " << info->egressConfig->burst.get() << "b";
       }
     }
     script << "\n";

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
@@ -200,11 +200,11 @@ private:
   {
     Info(const IntervalSet<uint16_t>& _nonEphemeralPorts,
          const Interval<uint16_t>& _ephemeralPorts,
-         const Option<routing::queueing::htb::cls::Config>& _htb,
+         const Option<routing::queueing::htb::cls::Config>& _egressConfig,
          const Option<pid_t>& _pid = None())
       : nonEphemeralPorts(_nonEphemeralPorts),
         ephemeralPorts(_ephemeralPorts),
-        htb(_htb),
+        egressConfig(_egressConfig),
         pid(_pid) {}
 
     // Non-ephemeral ports used by the container. It's possible that a
@@ -222,7 +222,7 @@ private:
 
     // Optional htb configuration for egress traffic. This may change
     // upon 'update'.
-    Option<routing::queueing::htb::cls::Config> htb;
+    Option<routing::queueing::htb::cls::Config> egressConfig;
 
     Option<pid_t> pid;
     Option<uint16_t> flowId;
@@ -330,7 +330,7 @@ private:
   // Determine the egress rate limit to apply to a container, either
   // None if no limit should be applied or some rate determined from
   // a fixed limit or a limit scaled by CPU.
-  Option<routing::queueing::htb::cls::Config> htbConfig(
+  Option<routing::queueing::htb::cls::Config> egressHTBConfig(
       const Resources& resources) const;
 
   // Return the scripts that will be executed in the child context.


### PR DESCRIPTION
This is needed to have consistent naming with ingress bandwidth related stuff.