### PR TITLE
Auto-enable limit enforcement feature on the XFS file system, to enforce set quotas.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/xfs/disk.cpp
+++ b/src/slave/containerizer/mesos/isolators/xfs/disk.cpp
@@ -136,6 +136,12 @@ static Option<Bytes> getSandboxDisk(
 
 Try<Isolator*> XfsDiskIsolatorProcess::create(const Flags& flags)
 {
+  Try<Nothing> enable = xfs::enableQuota(flags.work_dir);
+  if (enable.isError()) {
+    return Error("Failed to enable XFS project quotas on '" +
+                  flags.work_dir + "': " + enable.error());
+  }
+
   Try<Nothing> supported = isPathSupported(flags.work_dir);
   if (supported.isError()) {
     return Error(supported.error());

--- a/src/slave/containerizer/mesos/isolators/xfs/utils.hpp
+++ b/src/slave/containerizer/mesos/isolators/xfs/utils.hpp
@@ -145,6 +145,18 @@ Try<Nothing> setProjectId(
 Try<Nothing> clearProjectId(
     const std::string& directory);
 
+
+// Test whether XFS user, group or project quotas enforcement are
+// enabled on the filesystem at the given path.
+Try<bool> isUserQuotaEnforcementEnabled(const std::string& path);
+Try<bool> isGroupQuotaEnforcementEnabled(const std::string& path);
+Try<bool> isProjectQuotaEnforcementEnabled(const std::string& path);
+
+
+// Enable XFS project quotas (accounting and enforcement) on the
+// filesystem at the given path.
+Try<Nothing> enableQuota(const std::string& path);
+
 } // namespace xfs {
 } // namespace internal {
 } // namespace mesos {

--- a/src/tests/containerizer/xfs_quota_tests.cpp
+++ b/src/tests/containerizer/xfs_quota_tests.cpp
@@ -333,6 +333,16 @@ INSTANTIATE_TEST_CASE_P(
     ParamDiskQuota::Printer());
 
 
+// ROOT_XFS_NoProjectQuotaEnforcement sets up an XFS filesystem on
+// loopback with no project quota enforcement.
+class ROOT_XFS_NoProjectQuotaEnforcement : public ROOT_XFS_TestBase
+{
+public:
+  ROOT_XFS_NoProjectQuotaEnforcement()
+    : ROOT_XFS_TestBase("usrquota,grpquota,pqnoenforce") {}
+};
+
+
 TEST_F(ROOT_XFS_QuotaTest, QuotaGetSet)
 {
   prid_t projectId = 44;
@@ -2290,6 +2300,24 @@ TEST_F(ROOT_XFS_NoProjectQuota, CheckQuotaEnabled)
 {
   EXPECT_SOME_EQ(false, xfs::isQuotaEnabled(mountPoint.get()));
   EXPECT_ERROR(XfsDiskIsolatorProcess::create(CreateSlaveFlags()));
+}
+
+
+TEST_F(ROOT_XFS_NoProjectQuotaEnforcement, CheckQuotaEnabled)
+{
+  EXPECT_SOME_EQ(true, xfs::isUserQuotaEnforcementEnabled(mountPoint.get()));
+  EXPECT_SOME_EQ(true, xfs::isGroupQuotaEnforcementEnabled(mountPoint.get()));
+  EXPECT_SOME_EQ(
+      false, xfs::isProjectQuotaEnforcementEnabled(mountPoint.get()));
+
+  slave::Flags flags = CreateSlaveFlags();
+  Try<mesos::slave::Isolator*> isolator = XfsDiskIsolatorProcess::create(flags);
+  EXPECT_SOME(isolator);
+  delete isolator.get();
+
+  EXPECT_SOME_EQ(true, xfs::isUserQuotaEnforcementEnabled(mountPoint.get()));
+  EXPECT_SOME_EQ(true, xfs::isGroupQuotaEnforcementEnabled(mountPoint.get()));
+  EXPECT_SOME_EQ(true, xfs::isProjectQuotaEnforcementEnabled(mountPoint.get()));
 }
 
 


### PR DESCRIPTION
If quotas are set for the XFS disk isolator they will only be
enforced if the limit enforcement feature is enabled, and it
is not always enabled by default. This change will auto-enable
quota enforcement on the XFS disk isolator, to get the expected
quota enforcement behavior.
