### PR TITLE
Added ingress rate limiting to port_mapping isolator.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1887,6 +1887,9 @@ message ResourceStatistics {
   optional uint64 net_tx_rate_limit = 46;
   optional uint64 net_tx_burst_rate_limit = 47;
   optional uint64 net_tx_burst_size = 48;
+  optional uint64 net_rx_rate_limit = 49;
+  optional uint64 net_rx_burst_rate_limit = 50;
+  optional uint64 net_rx_burst_size = 51;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1851,6 +1851,9 @@ message ResourceStatistics {
   optional uint64 net_tx_rate_limit = 46;
   optional uint64 net_tx_burst_rate_limit = 47;
   optional uint64 net_tx_burst_size = 48;
+  optional uint64 net_rx_rate_limit = 49;
+  optional uint64 net_rx_burst_rate_limit = 50;
+  optional uint64 net_rx_burst_size = 51;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1270,6 +1270,43 @@ mesos::internal::slave::Flags::Flags()
       "root.",
       "root");
 
+  add(&Flags::ingress_rate_limit_per_container,
+      "ingress_rate_limit_per_container",
+      "The limit of the ingress traffic for each container, in Bytes/s.\n"
+      "If not specified or specified as zero, the network isolator will\n"
+      "impose no limits to containers' ingress traffic throughput.\n"
+      "This flag uses the Bytes type (defined in stout) and is used for\n"
+      "the `network/port_mapping` isolator.");
+
+  add(&Flags::ingress_rate_per_cpu,
+      "ingress_rate_per_cpu",
+      "Scale the limit of ingress traffic for each container by\n"
+      "ingress_rate_per_cpu Bytes/s for each whole unit of CPU resource,\n"
+      "i.e., floor(CPU), subject to the values of the\n"
+      "minimum_ingress_rate_limit and maximum_ingress_rate_limit flags."
+      "This flag is used by the `network/port_mapping` isolator,");
+
+  add(&Flags::minimum_ingress_rate_limit,
+      "minimum_ingress_rate_limit",
+      "Minimum limit of the ingress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::maximum_ingress_rate_limit,
+      "maximum_ingress_rate_limit",
+      "Maximum limit of the ingress traffic for each container, in Bytes/s."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::ingress_ceil_limit,
+      "ingress_ceil_limit",
+      "Additional ceil rate in Bytes/s that containers can burst up to\n"
+      "'ingress_burst' bytes at."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
+  add(&Flags::ingress_burst,
+      "ingress_burst",
+      "Amount of data in Bytes that can be received at the higher ceil rate."
+      "This flag is used by the `network/port_mapping_isolator`.");
+
   add(&Flags::network_enable_socket_statistics_summary,
       "network_enable_socket_statistics_summary",
       "Whether to collect socket statistics summary for each container.\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -160,6 +160,12 @@ public:
   Option<Bytes> egress_burst;
   bool egress_unique_flow_per_container;
   std::string egress_flow_classifier_parent;
+  Option<Bytes> ingress_rate_limit_per_container;
+  Option<Bytes> ingress_rate_per_cpu;
+  Option<Bytes> minimum_ingress_rate_limit;
+  Option<Bytes> maximum_ingress_rate_limit;
+  Option<Bytes> ingress_ceil_limit;
+  Option<Bytes> ingress_burst;
   bool network_enable_socket_statistics_summary;
   bool network_enable_socket_statistics_details;
   bool network_enable_snmp_statistics;

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1635,6 +1635,107 @@ TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallEgressLimit)
 }
 
 
+// Test the scenario where PortMappingIsolator uses a very small
+// ingress rate limit.
+TEST_F(PortMappingIsolatorTest, ROOT_NC_SmallIngressLimit)
+{
+  const Bytes rate = 2000;
+  const Bytes size = 20480;
+
+  flags.ingress_rate_limit_per_container = rate;
+  flags.minimum_ingress_rate_limit = 0;
+
+  Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
+  ASSERT_SOME(isolator);
+
+  Try<Launcher*> launcher = LinuxLauncher::create(flags);
+  ASSERT_SOME(launcher);
+
+  ExecutorInfo executorInfo;
+  executorInfo.mutable_resources()->CopyFrom(
+      Resources::parse(container1Ports).get());
+
+  ContainerID containerId;
+  containerId.set_value(id::UUID::random().toString());
+
+  Try<string> dir = os::mkdtemp(path::join(os::getcwd(), "XXXXXX"));
+  ASSERT_SOME(dir);
+
+  ContainerConfig containerConfig;
+  containerConfig.mutable_executor_info()->CopyFrom(executorInfo);
+  containerConfig.mutable_resources()->CopyFrom(executorInfo.resources());
+  containerConfig.set_directory(dir.get());
+
+  Future<Option<ContainerLaunchInfo>> launchInfo = isolator.get()->prepare(
+      containerId, containerConfig);
+  AWAIT_READY(launchInfo);
+  ASSERT_SOME(launchInfo.get());
+  ASSERT_EQ(1, launchInfo.get()->pre_exec_commands().size());
+
+  ostringstream cmd1;
+  cmd1 << "touch " << container1Ready << " && ";
+  cmd1 << "nc -l localhost " << validPort << " > /dev/null";
+
+  int pipes[2];
+  ASSERT_NE(-1, ::pipe(pipes));
+
+  Try<pid_t> pid = launchHelper(
+      launcher.get(),
+      pipes,
+      containerId,
+      cmd1.str(),
+      launchInfo.get());
+
+  ASSERT_SOME(pid);
+
+  // Reap the forked child.
+  Future<Option<int>> reap = process::reap(pid.get());
+
+  // Continue in the parent.
+  ::close(pipes[0]);
+
+  // Isolate the forked child.
+  AWAIT_READY(isolator.get()->isolate(containerId, pid.get()));
+
+  // Now signal the child to continue.
+  char dummy;
+  ASSERT_LT(0, ::write(pipes[1], &dummy, sizeof(dummy)));
+  ::close(pipes[1]);
+
+  // Wait for the command to finish.
+  ASSERT_TRUE(waitForFileCreation(container1Ready));
+
+  Result<htb::cls::Config> config = htb::cls::getConfig(
+      slave::PORT_MAPPING_VETH_PREFIX() + stringify(pid.get()),
+      routing::Handle(routing::Handle(1, 0), 1));
+  ASSERT_SOME(config);
+  EXPECT_EQ(rate, config->rate);
+
+  const string data(size.bytes(), 'a');
+
+  ostringstream cmd2;
+  cmd2 << "echo " << data << " | nc localhost " << validPort;
+
+  Stopwatch stopwatch;
+  stopwatch.start();
+  ASSERT_SOME(os::shell(cmd2.str()));
+  Duration time = stopwatch.elapsed();
+
+  // Allow the time to deviate up to 1sec here to compensate for burstness.
+  Duration expectedTime = Seconds(size.bytes() / rate.bytes() - 1);
+  ASSERT_GE(time, expectedTime);
+
+  // Ensure all processes are killed.
+  AWAIT_READY(launcher.get()->destroy(containerId));
+
+  // Let the isolator clean up.
+  AWAIT_READY(isolator.get()->cleanup(containerId));
+
+  delete isolator.get();
+  delete launcher.get();
+}
+
+
 TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPU)
 {
   flags.egress_rate_limit_per_container = None();
@@ -1736,6 +1837,119 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPU)
   AWAIT_READY(update);
 
   config = recoverHTBConfig(pid.get(), eth0, flags);
+  ASSERT_SOME(config);
+  ASSERT_EQ(maxRate, config->rate);
+
+  // Kill the container
+  AWAIT_READY(launcher.get()->destroy(containerId1));
+  AWAIT_READY(isolator.get()->cleanup(containerId1));
+}
+
+
+TEST_F(PortMappingIsolatorTest, ROOT_ScaleIngressWithCPU)
+{
+  flags.ingress_rate_limit_per_container = None();
+
+  const Bytes ingressRatePerCpu = 1000;
+  flags.ingress_rate_per_cpu = ingressRatePerCpu;
+
+  const Bytes minRate = 2000;
+  flags.minimum_ingress_rate_limit = minRate;
+
+  const Bytes maxRate = 4000;
+  flags.maximum_ingress_rate_limit = maxRate;
+
+  // CPU low enough for scaled network ingress to be increased to min
+  // limit: 1 * 1000 < 2000 ==> ingress is 2000.
+  Try<Resources> lowCpu = Resources::parse("cpus:1;mem:1024;disk:1024");
+  ASSERT_SOME(lowCpu);
+
+  // CPU sufficient to be in linear scaling region, greater than min
+  // and less than max: 2000 < 3.1 * 1000 < 4000.
+  Try<Resources> linearCpu = Resources::parse("cpus:3.1;mem:1024;disk:1024");
+  ASSERT_SOME(linearCpu);
+
+  // CPU high enough for scaled network ingress to be reduced to the
+  // max limit: 5 * 1000 > 4000.
+  Try<Resources> highCpu = Resources::parse("cpus:5;mem:1024;disk:1024");
+  ASSERT_SOME(highCpu);
+
+  Try<Isolator*> isolator = PortMappingIsolatorProcess::create(flags);
+  ASSERT_SOME(isolator);
+
+  Try<Launcher*> launcher = LinuxLauncher::create(flags);
+  ASSERT_SOME(launcher);
+
+  ExecutorInfo executorInfo;
+  executorInfo.mutable_resources()->CopyFrom(lowCpu.get());
+
+  ContainerID containerId1;
+  containerId1.set_value(id::UUID::random().toString());
+
+  ContainerConfig containerConfig1;
+  containerConfig1.mutable_executor_info()->CopyFrom(executorInfo);
+
+  Future<Option<ContainerLaunchInfo>> launchInfo1 =
+    isolator.get()->prepare(containerId1, containerConfig1);
+  AWAIT_READY(launchInfo1);
+  ASSERT_SOME(launchInfo1.get());
+  ASSERT_EQ(1, launchInfo1.get()->pre_exec_commands().size());
+
+  int pipes[2];
+  ASSERT_NE(-1, ::pipe(pipes));
+
+  Try<pid_t> pid = launchHelper(
+      launcher.get(),
+      pipes,
+      containerId1,
+      "touch " + container1Ready + " && sleep 1000",
+      launchInfo1.get());
+  ASSERT_SOME(pid);
+
+  // Reap the forked child.
+  Future<Option<int>> status = process::reap(pid.get());
+
+  // Continue in the parent.
+  ::close(pipes[0]);
+
+  // Isolate the forked child.
+  AWAIT_READY(isolator.get()->isolate(containerId1, pid.get()));
+
+  // Signal forked child to continue.
+  char dummy;
+  ASSERT_LT(0, ::write(pipes[1], &dummy, sizeof(dummy)));
+  ::close(pipes[1]);
+
+  // Wait for command to start to ensure all pre-exec scripts have
+  // executed.
+  ASSERT_TRUE(waitForFileCreation(container1Ready));
+
+  const string veth = slave::PORT_MAPPING_VETH_PREFIX() + stringify(pid.get());
+  const routing::Handle cls(routing::Handle(1, 0), 1);
+
+  Result<htb::cls::Config> config = htb::cls::getConfig(veth, cls);
+  ASSERT_SOME(config);
+  ASSERT_EQ(minRate, config->rate);
+
+  // Increase CPU to get to linear scaling.
+  Future<Nothing> update = isolator.get()->update(
+      containerId1,
+      linearCpu.get());
+  AWAIT_READY(update);
+
+  config = htb::cls::getConfig(veth, cls);
+  ASSERT_SOME(config);
+  ASSERT_EQ(
+      ingressRatePerCpu.bytes() * floor(linearCpu.get().cpus().get()),
+      config->rate);
+
+  // Increase CPU further to hit maximum limit.
+  update = isolator.get()->update(
+      containerId1,
+      highCpu.get());
+  AWAIT_READY(update);
+
+  config = htb::cls::getConfig(veth, cls);
   ASSERT_SOME(config);
   ASSERT_EQ(maxRate, config->rate);
 


### PR DESCRIPTION
This change adds support to network/port_mapping isolator for limiting ingress bandwidth of the container. Scaling with CPU and min/max limits are supported.

Ingress bandwidth limiting is achieved by installing an HTB qdisc with a rate limiting class on the veth of the container. An ECN enabled fq_codel qdisc is then added for buffer-bloat reduction.