### PR TITLE
Improved performance of RatesCollector in network/port_mapping isolator.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -62,6 +62,7 @@
 #include "linux/fs.hpp"
 #include "linux/ns.hpp"
 
+#include "linux/routing/internal.hpp"
 #include "linux/routing/route.hpp"
 #include "linux/routing/utils.hpp"
 
@@ -73,6 +74,7 @@
 
 #include "linux/routing/handle.hpp"
 
+#include "linux/routing/link/internal.hpp"
 #include "linux/routing/link/link.hpp"
 #include "linux/routing/link/veth.hpp"
 
@@ -1553,20 +1555,13 @@ Option<Statistics<uint64_t>> PercentileRatesCollector::txErrorRate() const
 }
 
 
-void PercentileRatesCollector::sample()
-{
-  const Time ts = Clock::now();
-
-  Result<hashmap<string, uint64_t>> stats = link::statistics(link);
-  if (stats.isSome()) {
-    sample(ts, std::move(stats.get()));
-  }
-}
-
-
 void PercentileRatesCollector::sample(
     const Time& ts, hashmap<string, uint64_t>&& statistics)
 {
+  if (statistics.empty()) {
+    return;
+  }
+
   if (previous.isSome() && previous.get() < ts) {
     // We sample statistics on the host end of the veth pair, so we
     // need to reverse RX and TX to get statistics inside the
@@ -1617,7 +1612,7 @@ public:
 
   void initialize() override
   {
-    schedule();
+    sample();
   }
 
   Future<ResourceStatistics> usage(const ContainerID& containerId)
@@ -1689,13 +1684,54 @@ public:
   }
 
 private:
-  void schedule()
+  // This method is mostly a copy of routing::link::statistics(), but
+  // with the ability to use the existing links cache. It was copied
+  // here to preserve libnl-agnostic interface of routing package and
+  // ease the cleanup when this collector will be replaced with eBPF.
+  static hashmap<string, uint64_t> statistics(
+      const Netlink<struct nl_cache>& cache,
+      const string& link)
   {
-    foreachvalue (PercentileRatesCollector& collector, collectors) {
-      collector.sample();
+    hashmap<string, uint64_t> results;
+
+    struct rtnl_link* l = rtnl_link_get_by_name(cache.get(), link.c_str());
+    if (l) {
+      Netlink<struct rtnl_link> _link(l);
+
+      rtnl_link_stat_id_t stats[] = {
+        RTNL_LINK_RX_PACKETS,
+        RTNL_LINK_RX_BYTES,
+        RTNL_LINK_RX_ERRORS,
+        RTNL_LINK_RX_DROPPED,
+        RTNL_LINK_TX_PACKETS,
+        RTNL_LINK_TX_BYTES,
+        RTNL_LINK_TX_ERRORS,
+        RTNL_LINK_TX_DROPPED,
+      };
+
+      char buf[32];
+      size_t size = sizeof(stats) / sizeof(stats[0]);
+      for (size_t i = 0; i < size; i++) {
+        rtnl_link_stat2str(stats[i], buf, 32);
+        results[buf] = rtnl_link_get_stat(_link.get(), stats[i]);
+      }
     }
 
-    delay(interval, self(), &Self::schedule);
+    return results;
+  }
+
+  void sample()
+  {
+    const Time timestamp = Clock::now();
+
+    Try<Netlink<struct nl_cache>> cache = link::internal::get();
+    if (cache.isSome()) {
+      foreachvalue (PercentileRatesCollector& collector, collectors) {
+        collector.sample(timestamp, statistics(cache.get(), collector.link));
+      }
+    }
+
+    delay(interval, self(), &Self::sample);
   }
 
   void copyRate(

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
@@ -173,11 +173,11 @@ public:
   Option<process::Statistics<uint64_t>> txDropRate() const;
   Option<process::Statistics<uint64_t>> txErrorRate() const;
 
-  // Sample statistics from the interface.
-  void sample();
-
-  // Register the statistics sample. Exposed for testing.
+  // Register the statistics sample.
   void sample(const process::Time& ts, hashmap<std::string, uint64_t>&& stats);
+
+  // Name of the link to sample metrics from.
+  const std::string link;
 
 private:
   void sampleRate(
@@ -186,9 +186,6 @@ private:
       const process::Time& timestamp,
       double timeDelta,
       process::TimeSeries<uint64_t>& rates);
-
-  // Name of the link to sample metrics from.
-  const std::string link;
 
   process::TimeSeries<uint64_t> rxRates;
   process::TimeSeries<uint64_t> rxPackets;


### PR DESCRIPTION
To get a single link info utilities in routing::link pull all configured links infos from the kernel. With this change RatesCollector pulls the link cache only once per sampling round.