### PR TITLE
[FIX] Conflicting field ids in RateStatistics

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1937,7 +1937,7 @@ message ResourceStatistics {
     optional double sampling_interval_secs = 10;
   }
 
-  optional RateStatistics net_rate_statistics = 51;
+  optional RateStatistics net_rate_statistics = 54;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1901,7 +1901,7 @@ message ResourceStatistics {
     optional double sampling_interval_secs = 10;
   }
 
-  optional RateStatistics net_rate_statistics = 51;
+  optional RateStatistics net_rate_statistics = 54;
 
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.


### PR DESCRIPTION
`net_rate_statistics` and `net_rx_burst_size` both had field number 51. `net_rate_statistics`, the new field, has been changed to field 54 in RateStatistics.