### PR TITLE
Added auto calculation of ingress_rate_per_cpu.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
@@ -342,7 +342,8 @@ private:
       const IntervalSet<uint16_t>& _managedNonEphemeralPorts,
       const process::Owned<EphemeralPortsAllocator>& _ephemeralPortsAllocator,
       const std::set<uint16_t>& _flowIDs,
-      const process::Owned<RatesCollector>& _ratesCollector);
+      const process::Owned<RatesCollector>& _ratesCollector,
+      const Option<Bytes>& _ingressRatePerCpu);
 
   // Continuations.
   Try<Nothing> _cleanup(Info* info, const Option<ContainerID>& containerId);
@@ -422,6 +423,8 @@ private:
   hashset<ContainerID> unmanaged;
 
   process::Owned<RatesCollector> ratesCollector;
+
+  const Option<Bytes> ingressRatePerCpu;
 };
 
 

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1307,6 +1307,13 @@ mesos::internal::slave::Flags::Flags()
       "Amount of data in Bytes that can be received at the higher ceil rate."
       "This flag is used by the `network/port_mapping_isolator`.");
 
+  add(&Flags::network_link_speed,
+      "network_link_speed",
+      "Physical network link speed in Bytes/s. This flag is used only when\n"
+      "--ingress_rate_per_cpu=\'auto\'. This provided link speed overrides\n"
+      "automatic detection of the link speed. This flag is used by the\n"
+      "`network/port_mapping_isolator`.");
+
   add(&Flags::network_enable_socket_statistics_summary,
       "network_enable_socket_statistics_summary",
       "Whether to collect socket statistics summary for each container.\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -161,11 +161,12 @@ public:
   bool egress_unique_flow_per_container;
   std::string egress_flow_classifier_parent;
   Option<Bytes> ingress_rate_limit_per_container;
-  Option<Bytes> ingress_rate_per_cpu;
+  Option<std::string> ingress_rate_per_cpu;
   Option<Bytes> minimum_ingress_rate_limit;
   Option<Bytes> maximum_ingress_rate_limit;
   Option<Bytes> ingress_ceil_limit;
   Option<Bytes> ingress_burst;
+  Option<Bytes> network_link_speed;
   bool network_enable_socket_statistics_summary;
   bool network_enable_socket_statistics_details;
   bool network_enable_snmp_statistics;


### PR DESCRIPTION
Currently ingress rate limit scaling requires manual configuration of per CPU rate limit.
While it is more predictable and gives rounder values, in a heterogeneous environment
where hosts with one NIC type have different CPUs it may be cumbersome to configure.

This commit allows you to pass an "auto" value to the `--ingress_rate_per_cpu` flag
of the isolator
```
--ingress_rate_per_cpu=auto
```
to automatically calculate the value. The value is calculated by determining the
link speed using the `/sys/class/net/<iface>/speed` interface
(https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net) and dividing the
speed by the number of CPUs resources that are available.  `--ingress_rate_per_cpu=auto`
will fail if there are 0 CPU resources.

An additional flag
```
--network_link_speed=<link speed in bytes/second>
```
is provided to override link speed detection when `--ingress_rate_per_cpu=auto`.