### PR TITLE
Exported container ephemeral ports range in ResourceStatistics.

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -1939,6 +1939,9 @@ message ResourceStatistics {
 
   optional RateStatistics net_rate_statistics = 54;
 
+  // Inclusive ephemeral ports range of the container.
+  optional Value.Range net_ephemeral_ports = 55;
+
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.
   optional double net_tcp_rtt_microsecs_p50 = 22;

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -1903,6 +1903,9 @@ message ResourceStatistics {
 
   optional RateStatistics net_rate_statistics = 54;
 
+  // Inclusive ephemeral ports range of the container.
+  optional Value.Range net_ephemeral_ports = 55;
+
   // The kernel keeps track of RTT (round-trip time) for its TCP
   // sockets. RTT is a way to tell the latency of a container.
   optional double net_tcp_rtt_microsecs_p50 = 22;

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -4233,6 +4233,18 @@ Future<ResourceStatistics> PortMappingIsolatorProcess::usage(
     }
   }
 
+  // Include ephemeral ports range of the container. Check for an
+  // empty interval, because the container may have no ephemeral ports
+  // if it was only partially isolated due to agent crash.
+  // 
+  // Note: Interval::upper() is exclusive, however, net_ephemeral_ports::end is
+  //       inclusive, so we substract from Interval::upper().
+  if (info->ephemeralPorts != Interval<uint16_t>()) {
+    Value::Range* const ports = result.mutable_net_ephemeral_ports();
+    ports->set_begin(info->ephemeralPorts.lower());
+    ports->set_end(info->ephemeralPorts.upper() - 1);
+  }
+
   // Retrieve the socket information from inside the container.
   PortMappingStatistics statistics;
   statistics.flags.pid = info->pid.get();


### PR DESCRIPTION
Adds the container's ephemeral port range to ResourceStatistics in a new field net_ephemeral_ports, which stores the inclusive range.