### PR TITLE
Added ingress rate limit enabling for existing containers.

### DIFF
--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1307,6 +1307,18 @@ mesos::internal::slave::Flags::Flags()
       "Amount of data in Bytes that can be received at the higher ceil rate."
       "This flag is used by the `network/port_mapping_isolator`.");
 
+  add(&Flags::ingress_isolate_existing_containers,
+      "ingress_isolate_existing_containers",
+      "Whether to turn on ingress bandwidth isolation for already running\n"
+      "containers that don't have the ingress isolation enabled. This flag\n"
+      "exists for synchronization with ECN support enabling. ECNs are used by\n"
+      "the ingress bandwidth limiting mechanism to avoid dropping packets.\n"
+      "The use of ECNs has to be negotiated between the endpoints during the\n"
+      "TCP handshake and thus ECN support has to be enabled at the time when\n"
+      "the containers are launched. This flag is used by the\n"
+      "`network/port_mapping` isolator.",
+      true);
+
   add(&Flags::network_link_speed,
       "network_link_speed",
       "Physical network link speed in Bytes/s. This flag is used only when\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -166,6 +166,7 @@ public:
   Option<Bytes> maximum_ingress_rate_limit;
   Option<Bytes> ingress_ceil_limit;
   Option<Bytes> ingress_burst;
+  bool ingress_isolate_existing_containers;
   Option<Bytes> network_link_speed;
   bool network_enable_socket_statistics_summary;
   bool network_enable_socket_statistics_details;


### PR DESCRIPTION
Previously, changes to the ingress HTB config, including ingress rate limiting and container isolation, could not be applied at runtime, to avoid dropping packets. This change introduces a flag `--ingress_isolate_existing_containers` that enables these changes to be applied to existing containers. This allows migrations to ECN support (https://en.wikipedia.org/wiki/Explicit_Congestion_Notification) to be possible, without having to reboot hosts or restart containers.

Previously the network/port_mapping isolator didn't set ingress rate limit for existing contaners without it in order to avoid dropping packets, because we thought that we will turn on ECN support without rebooting the hosts and thus restarting the containers.