### PR TITLE
Added per-CPU rate limit metrics.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -1940,7 +1940,11 @@ PortMappingIsolatorProcess::Metrics::Metrics()
     updating_eth0_arp_filters_do_not_exist(
         "port_mapping/updating_eth0_arp_filters_do_not_exist"),
     updating_container_ip_filters_errors(
-        "port_mapping/updating_container_ip_filters_errors")
+        "port_mapping/updating_container_ip_filters_errors"),
+    per_cpu_egress_rate_limit(
+        "port_mapping/per_cpu_egress_rate_limit"),
+    per_cpu_ingress_rate_limit(
+        "port_mapping/per_cpu_ingress_rate_limit")
 {
   process::metrics::add(adding_eth0_ip_filters_errors);
   process::metrics::add(adding_eth0_ip_filters_already_exist);
@@ -1973,6 +1977,8 @@ PortMappingIsolatorProcess::Metrics::Metrics()
   process::metrics::add(updating_eth0_arp_filters_already_exist);
   process::metrics::add(updating_eth0_arp_filters_do_not_exist);
   process::metrics::add(updating_container_ip_filters_errors);
+  process::metrics::add(per_cpu_egress_rate_limit);
+  process::metrics::add(per_cpu_ingress_rate_limit);
 }
 
 
@@ -2009,6 +2015,8 @@ PortMappingIsolatorProcess::Metrics::~Metrics()
   process::metrics::remove(updating_eth0_arp_filters_already_exist);
   process::metrics::remove(updating_eth0_arp_filters_do_not_exist);
   process::metrics::remove(updating_container_ip_filters_errors);
+  process::metrics::remove(per_cpu_egress_rate_limit);
+  process::metrics::remove(per_cpu_ingress_rate_limit);
 }
 
 
@@ -2890,7 +2898,10 @@ PortMappingIsolatorProcess::PortMappingIsolatorProcess(
     ratesCollector(_ratesCollector),
     egressRatePerCpu(_egressRatePerCpu),
     ingressRatePerCpu(_ingressRatePerCpu)
-{}
+{
+  metrics.per_cpu_egress_rate_limit = egressRatePerCpu.getOrElse(0).bytes();
+  metrics.per_cpu_ingress_rate_limit = ingressRatePerCpu.getOrElse(0).bytes();
+}
 
 
 Result<htb::cls::Config> recoverHTBConfig(

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.hpp
@@ -32,6 +32,7 @@
 
 #include <process/metrics/metrics.hpp>
 #include <process/metrics/counter.hpp>
+#include <process/metrics/push_gauge.hpp>
 
 #include <stout/bytes.hpp>
 #include <stout/hashmap.hpp>
@@ -326,6 +327,8 @@ private:
     process::metrics::Counter updating_eth0_arp_filters_already_exist;
     process::metrics::Counter updating_eth0_arp_filters_do_not_exist;
     process::metrics::Counter updating_container_ip_filters_errors;
+    process::metrics::PushGauge per_cpu_egress_rate_limit;
+    process::metrics::PushGauge per_cpu_ingress_rate_limit;
   } metrics;
 
   PortMappingIsolatorProcess(

--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1892,6 +1892,11 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPUAutoConfig)
   Try<Launcher*> launcher = LinuxLauncher::create(flags);
   ASSERT_SOME(launcher);
 
+  // The isolator should report the calculated per-CPU limit as a metric.
+  JSON::Object metrics = Metrics();
+  EXPECT_EQ(egressRatePerCpu.bytes(),
+            metrics.values["port_mapping/per_cpu_egress_rate_limit"]);
+
   ExecutorInfo executorInfo;
   executorInfo.mutable_resources()->CopyFrom(lowCpu.get());
 
@@ -2126,6 +2131,11 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleIngressWithCPUAutoConfig)
 
   Try<Launcher*> launcher = LinuxLauncher::create(flags);
   ASSERT_SOME(launcher);
+
+  // The isolator should report the calculated per-CPU limit as a metric.
+  JSON::Object metrics = Metrics();
+  EXPECT_EQ(ingressRatePerCpu.bytes(),
+            metrics.values["port_mapping/per_cpu_ingress_rate_limit"]);
 
   ExecutorInfo executorInfo;
   executorInfo.mutable_resources()->CopyFrom(lowCpu.get());


### PR DESCRIPTION
The new metrics show the amount of egress and ingress bandwidth that a container gets per whole unit of its CPU reservation. The values are 0 when limit scaling is not enabled.

Metric names:
```
port_mapping/per_cpu_egress_rate_limit
port_mapping/per_cpu_ingress_rate_limit
```