### PR TITLE
[FIX] Rate overflow in port_mapping isolator.

### DIFF
--- a/m4/libnl3.m4
+++ b/m4/libnl3.m4
@@ -23,7 +23,7 @@ AC_DEFUN([MESOS_MSG_LIBNL3_ERROR], [
 
 AC_MSG_ERROR([$1
 -------------------------------------------------------------------
-Please install libnl3 (version 3.2.26 or higher):
+Please install libnl3 (version 3.5.0 or higher):
 https://github.com/thom311/libnl/releases
 -------------------------------------------------------------------
 ])
@@ -52,6 +52,25 @@ AS_IF([test x$ac_mesos_have_libnl3 = x], [
     CPPFLAGS="-I/usr/include/libnl3 $CPPFLAGS"
   ])
 ])
+
+# Check for version 3.5.0 or higher.
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <netlink/version.h>
+
+int main() {
+  if (LIBNL_VER_MAJ < 3) {
+    return 1;
+  } else if (LIBNL_VER_MAJ > 3) {
+    return 0;
+  }
+
+  if (LIBNL_VER_MIN < 5) {
+    return 1;
+  } 
+
+  return 0;
+}
+]])], [], [ac_mesos_have_libnl3=no], [])
 
 AC_CHECK_HEADERS(
   [netlink/netlink.h netlink/route/link/veth.h],

--- a/src/linux/routing/queueing/htb.hpp
+++ b/src/linux/routing/queueing/htb.hpp
@@ -28,6 +28,12 @@
 
 #include "linux/routing/handle.hpp"
 
+#include <netlink/version.h>
+
+#if LIBNL_VER_MAJ < 3 || (LIBNL_VER_MAJ == 3 && LIBNL_VER_MIN < 5)
+#error libnl3 >= 3.5 required. Please update your installed libnl3 version.
+#endif
+
 namespace routing {
 namespace queueing {
 namespace htb {

--- a/src/linux/routing/queueing/htb.hpp
+++ b/src/linux/routing/queueing/htb.hpp
@@ -81,8 +81,8 @@ namespace cls {
 struct Config
 {
   Config(
-      uint32_t _rate,
-      Option<uint32_t> _ceil = None(),
+      uint64_t _rate,
+      Option<uint64_t> _ceil = None(),
       Option<uint32_t> _burst = None())
     : rate(_rate),
       ceil(_ceil),
@@ -99,9 +99,9 @@ struct Config
 
   // Normal rate limit. The size of the normal rate bucket is not
   // exposed and will be computed by the kernel.
-  uint32_t rate;
+  uint64_t rate;
   // Burst limit.
-  Option<uint32_t> ceil;
+  Option<uint64_t> ceil;
   // Size of the burst bucket.
   Option<uint32_t> burst;
 };

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -5077,7 +5077,8 @@ Option<htb::cls::Config> PortMappingIsolatorProcess::egressHTBConfig(
   if (flags.egress_rate_limit_per_container.isSome()) {
     rate = flags.egress_rate_limit_per_container.get();
   } else if (egressRatePerCpu.isSome()) {
-    rate = egressRatePerCpu.get() * floor(resources.cpus().getOrElse(0));
+    rate = egressRatePerCpu.get() *
+      static_cast<uint64_t>(resources.cpus().getOrElse(0));
   } else {
     return None();
   }
@@ -5115,7 +5116,8 @@ Option<htb::cls::Config> PortMappingIsolatorProcess::ingressHTBConfig(
   if (flags.ingress_rate_limit_per_container.isSome()) {
     rate = flags.ingress_rate_limit_per_container.get();
   } else if (ingressRatePerCpu.isSome()) {
-    rate = ingressRatePerCpu.get() * floor(resources.cpus().getOrElse(0));
+    rate = ingressRatePerCpu.get() *
+      static_cast<uint64_t>(resources.cpus().getOrElse(0));
   } else {
     return None();
   }
@@ -5292,10 +5294,11 @@ string PortMappingIsolatorProcess::scripts(Info* info)
     script << "tc class add dev " << eth0 << " parent "
            << CONTAINER_TX_HTB_HANDLE << " classid "
            << CONTAINER_TX_HTB_CLASS_ID << " htb rate "
-           << info->egressConfig->rate * 8 << "bit";
+           << static_cast<uint64_t>(info->egressConfig->rate) * 8 << "bit";
     if (info->egressConfig->ceil.isSome()) {
       script << " ceil "
-             << info->egressConfig->ceil.get() * 8 << "bit";
+             << static_cast<uint64_t>(info->egressConfig->ceil.get()) * 8
+             << "bit";
       if (info->egressConfig->burst.isSome()) {
         // Use bytes here because tc command borks at bits.
         script << " burst " << info->egressConfig->burst.get() << "b";

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -617,8 +617,8 @@ static Result<htb::cls::Config> parseHTBConfig(const JSON::Object& object)
   }
 
   return htb::cls::Config(
-      rate->as<uint32_t>(),
-      ceil.isSome() ? Option<uint32_t>(ceil->as<uint32_t>())
+      rate->as<uint64_t>(),
+      ceil.isSome() ? Option<uint64_t>(ceil->as<uint64_t>())
                     : None(),
       burst.isSome() ? Option<uint32_t>(burst->as<uint32_t>())
                      : None());
@@ -5093,7 +5093,7 @@ Option<htb::cls::Config> PortMappingIsolatorProcess::egressHTBConfig(
     rate = std::min(flags.maximum_egress_rate_limit.get(), rate);
   }
 
-  Option<uint32_t> ceil;
+  Option<uint64_t> ceil;
   Option<uint32_t> burst;
 
   if (flags.egress_ceil_limit.isSome() &&
@@ -5132,7 +5132,7 @@ Option<htb::cls::Config> PortMappingIsolatorProcess::ingressHTBConfig(
     rate = std::min(flags.maximum_ingress_rate_limit.get(), rate);
   }
 
-  Option<uint32_t> ceil;
+  Option<uint64_t> ceil;
   Option<uint32_t> burst;
 
   if (flags.ingress_ceil_limit.isSome() &&

--- a/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
+++ b/src/slave/containerizer/mesos/isolators/network/port_mapping.cpp
@@ -5294,10 +5294,10 @@ string PortMappingIsolatorProcess::scripts(Info* info)
     script << "tc class add dev " << eth0 << " parent "
            << CONTAINER_TX_HTB_HANDLE << " classid "
            << CONTAINER_TX_HTB_CLASS_ID << " htb rate "
-           << static_cast<uint64_t>(info->egressConfig->rate) * 8 << "bit";
+           << info->egressConfig->rate * 8 << "bit";
     if (info->egressConfig->ceil.isSome()) {
       script << " ceil "
-             << static_cast<uint64_t>(info->egressConfig->ceil.get()) * 8
+             << info->egressConfig->ceil.get() * 8
              << "bit";
       if (info->egressConfig->burst.isSome()) {
         // Use bytes here because tc command borks at bits.


### PR DESCRIPTION
Commits:
- Fix 32-bit overflow in the port mapping isolator.
- [Compile time] Enforce use of libnl3 >= 3.5.
- [Run time] Enforce use of libnl3 >= 3.5.
- Make use of new libnl3 64 bit API to eliminate potential overflows.

The port mapping isolator currently uses uint32_t to store container rate limits as B/s. The use of this data type is dictated by the current libnl interface, that the isolator uses to interface with netlink.

Container preparation phase in the isolator involves setting up TX rate limiting HTB class using tc command that wants rate to be represented as bits/s. The conversion is performed by a simple multiplication of the rate by a literal 8. The result of such multiplication is uint32_t that can hold a maximum value of 4294967295, which is not enough to represent speeds available to us on modern 25G links as bits/s.

This change fixes the described overflow issue. However, representing network rates as 32bit integers still presents a problem on hosts with more advanced links, e.g. 100G. Hence, we update the required version of libnl to libnl >=3.5 to get access to the APIs uint64_t rates, eliminating potential overflows.