### PR TITLE
[FIX] Add missing memory deallocation in port_mapping_tests.

### DIFF
--- a/src/tests/containerizer/port_mapping_tests.cpp
+++ b/src/tests/containerizer/port_mapping_tests.cpp
@@ -1844,6 +1844,9 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleEgressWithCPU)
   // Kill the container
   AWAIT_READY(launcher.get()->destroy(containerId1));
   AWAIT_READY(isolator.get()->cleanup(containerId1));
+
+  delete launcher.get();
+  delete isolator.get();
 }
 
 
@@ -2078,6 +2081,9 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleIngressWithCPU)
   // Kill the container
   AWAIT_READY(launcher.get()->destroy(containerId1));
   AWAIT_READY(isolator.get()->cleanup(containerId1));
+
+  delete launcher.get();
+  delete isolator.get();
 }
 
 
@@ -2203,6 +2209,9 @@ TEST_F(PortMappingIsolatorTest, ROOT_ScaleIngressWithCPUAutoConfig)
   // Kill the container
   AWAIT_READY(launcher.get()->destroy(containerId1));
   AWAIT_READY(isolator.get()->cleanup(containerId1));
+
+  delete launcher.get();
+  delete isolator.get();
 }
 
 


### PR DESCRIPTION
Several port mapping isolator tests were missing deallocations, of structures used in the tests. This commit adds these deallocations where they are missing.