### PR TITLE
Improve flag descriptions for --ingress_rate_per_cpu and --egress_rate_per_cpu.

### DIFF
--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -1235,7 +1235,7 @@ mesos::internal::slave::Flags::Flags()
       "If set to 'auto' the rate limit is automatically calculated\n"
       "by determining the link speed and dividing by the number of available\n"
       "CPU resources.\n" 
-      "This flag is used by the `network/port_mapping` isolator,");
+      "This flag is used by the `network/port_mapping` isolator.");
 
   add(&Flags::minimum_egress_rate_limit,
       "minimum_egress_rate_limit",
@@ -1287,6 +1287,9 @@ mesos::internal::slave::Flags::Flags()
       "ingress_rate_per_cpu Bytes/s for each whole unit of CPU resource,\n"
       "i.e., floor(CPU), subject to the values of the\n"
       "minimum_ingress_rate_limit and maximum_ingress_rate_limit flags."
+      "If set to 'auto' the rate limit is automatically calculated\n"
+      "by determining the link speed and dividing by the number of available\n"
+      "CPU resources.\n" 
       "This flag is used by the `network/port_mapping` isolator.");
 
   add(&Flags::minimum_ingress_rate_limit,


### PR DESCRIPTION
Addresses a typo in the --egress_rate_per_cpu flag and a missing description for
```
--ingress_rate_per_cpu='auto'
```