### PR TITLE
Added ENABLE_JEMALLOC_ALLOCATOR macro.

### DIFF
--- a/cmake/CompilationConfigure.cmake
+++ b/cmake/CompilationConfigure.cmake
@@ -491,6 +491,10 @@ if (LINUX)
     "Use jemalloc as memory allocator for the master and agent binaries."
     FALSE)
 
+  if (ENABLE_JEMALLOC_ALLOCATOR)
+    add_definitions(-DENABLE_JEMALLOC_ALLOCATOR)
+  endif ()
+
   option(ENABLE_XFS_DISK_ISOLATOR
     "Whether to enable the XFS disk isolator."
     FALSE)

--- a/configure.ac
+++ b/configure.ac
@@ -1306,6 +1306,8 @@ correct if you're already doing this.
   else
     with_bundled_jemalloc=yes
   fi
+
+  AC_DEFINE([ENABLE_JEMALLOC_ALLOCATOR])
 fi
 
 AC_SUBST(WITH_JEMALLOC)


### PR DESCRIPTION
Summary:
The macro is used in the agent code to determine if jemalloc was enabled in the build and provide a custom allocator configuration in the form of a global malloc_conf variable.

This commit follows from https://github.com/apache/mesos/commit/2836057c8881a62139b5db1f175d3d027bf2e645. View the commit for more details.

Test Plan:
Modified the agent code to print whether the macro is defined or not and tested on an integration test host.