### PR TITLE
Remove boost-<version>.patch requirement to fix autotools build

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -216,13 +216,9 @@ if ("${BOOST_ROOT_DIR}" STREQUAL "")
   endif ()
   target_include_directories(boost INTERFACE ${BOOST_ROOT})
 
-  # Patch Boost to avoid repeated "Unknown compiler warnings" on Windows.
-  PATCH_CMD(BOOST_PATCH_CMD boost-${BOOST_VERSION}.patch)
-
   ExternalProject_Add(
     ${BOOST_TARGET}
     PREFIX            ${BOOST_CMAKE_ROOT}
-    PATCH_COMMAND     ${BOOST_PATCH_CMD}
     CONFIGURE_COMMAND ${CMAKE_NOOP}
     BUILD_COMMAND     ${CMAKE_NOOP}
     INSTALL_COMMAND   ${CMAKE_NOOP}

--- a/3rdparty/Makefile.am
+++ b/3rdparty/Makefile.am
@@ -139,7 +139,6 @@ EXTRA_DIST +=			\
 
 # We need the following patches for CMake and/or Windows builds.
 EXTRA_DIST +=			\
-  $(BOOST).patch		\
   $(GOOGLETEST).patch		\
   $(LIBARCHIVE).patch		\
   $(PROTOBUF).patch		\


### PR DESCRIPTION
The patch that was used in boost 1.65.0 is no longer required for boost 1.81.0, however, the Mesos build systems still expect it.

This patch removes the need for a boost patch, when building Mesos thus fixing the broken builds.