### PR TITLE
Python autoconf configuration and logging improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2502,15 +2502,13 @@ if test "x$enable_python" = "xyes" || \
     AC_MSG_ERROR([only specify one of PYTHON or PYTHON_VERSION])
   fi
 
-  if test -n "$PYTHON"; then
-    PYTHON_VERSION=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`
-  fi
-
   if test -n "$PYTHON_VERSION"; then
+    # Set $PYTHON using $PYTHON_VERSION
     AC_SUBST([PYTHON], [python$PYTHON_VERSION])
-  fi
-
-  if test -z "$PYTHON" && test -z "$PYTHON_VERSION"; then
+  elif test -n "$PYTHON"; then
+    # Set $PYTHON_VERSION using $PYTHON
+    PYTHON_VERSION=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`
+  else
     AM_PATH_PYTHON()
   fi
 fi
@@ -2521,7 +2519,7 @@ if test "x$enable_python" = "xyes"; then
   AM_PYTHON_CHECK_VERSION([$PYTHON], [2.6], [],
                  [AC_MSG_ERROR([Mesos requires Python >= 2.6
 -------------------------------------------------------------------
-The detected Python version is $PYTHON_VERSION.
+The detected Python version is $PYTHON_VERSION from $PYTHON.
 
 If you already have Python 2.6+ installed (and it's the default python
 on the path), you might want to check if you have the PYTHON environment
@@ -2532,7 +2530,7 @@ variable set to an older version of Python.
   AM_PYTHON_CHECK_VERSION([$PYTHON], [3.0],
                  [AC_MSG_ERROR([Mesos requires Python < 3.0
 -------------------------------------------------------------------
-The detected Python version is $PYTHON_VERSION.
+The detected Python version is $PYTHON_VERSION from $PYTHON.
 
 If you already have Python 2.6+ installed (and it's the default python
 on the path), you might want to check if you have the PYTHON environment
@@ -2543,7 +2541,8 @@ variable set to a version of Python greater than 3.0.
   if test "x$enable_new_cli" = "xyes" && test -z "$PYTHON_3"; then
     AC_MSG_ERROR([Missing PYTHON_3 environment variable
 -------------------------------------------------------------------
-The detected Python version is $PYTHON_VERSION. Python 3 not detected.
+The detected Python version is $PYTHON_VERSION from $PYTHON.
+Python 3 not detected.
 
 When building both the Python bindings and the CLI, the detected Python
 version is used to build the bindings and PYTHON_3 must be set


### PR DESCRIPTION
Recently ran into a issue where `AM_PYTHON_CHECK_VERSION` was failing with code 127 "command not found" despite that the `$PYTHON` value set by the user when `./configure` was invoked was valid.

This was resulting in the following error message: """
configure: error: Mesos requires Python >= 2.6
------------------------------------------------------------------- The detected Python version is 2.7.

If you already have Python 2.6+ installed (and it's the default python on the path), you might want to check if you have the PYTHON environment variable set to an older version of Python.
------------------------------------------------------------------- """

Which is rather confusing: 
> "Requires Python >= 2.6 but finds 2.7 and throws an error?!"

What was happening is that:
1. $PYTHON=<path to python>
2. $PYTHON was being used to set $PYTHON_VERSION
3. $PYTHON_VERSION was then being used to update $PYTHON
```
  if test -n "$PYTHON_VERSION"; then
    AC_SUBST([PYTHON], [python$PYTHON_VERSION])
  fi
```
4. This made $PYTHON="python2.7" which was not in the path.
5. AM_PYTHON_CHECK_VERSION was called which was failing to find python2.7
6. We received an error.

To fix this, we change the conditional logic.
1. If $PYTHON is set, use it to set $PYTHON_VERSION.
2. Otherwise, if $PYTHON_VERSION is set then we use it
   to set $PYTHON.
3. Otherwise (both are unset), and we use the default
   configuration.

This will preserve the value of $PYTHON, if it was provided. In other words,
$PYTHON=/usr/bin/python2.7 will not become $PYTHON=python2.7 (the
problem), but will remain $PYTHON=/usr/bin/python2.7.

To make similar issues more obvious in the future, we additionally log
the current values of $PYTHON_VERSION **and** $PYTHON in the error
message.