### PR TITLE
Avoid using MSVC-internal `_STRINGIZE`

### DIFF
--- a/3rdparty/stout/include/stout/abort.hpp
+++ b/3rdparty/stout/include/stout/abort.hpp
@@ -28,14 +28,11 @@
 
 #include <stout/attributes.hpp>
 
-// NOTE: These macros are already defined in Visual Studio (Windows) headers.
-#ifndef __WINDOWS__
-#define __STRINGIZE(x) #x
-#define _STRINGIZE(x) __STRINGIZE(x)
-#endif // __WINDOWS__
+#define STOUT_STRINGIZE_IMPL(x) #x
+#define STOUT_STRINGIZE(x) STOUT_STRINGIZE_IMPL(x)
 
 // Signal safe abort which prints a message.
-#define _ABORT_PREFIX "ABORT: (" __FILE__ ":" _STRINGIZE(__LINE__) "): "
+#define _ABORT_PREFIX "ABORT: (" __FILE__ ":" STOUT_STRINGIZE(__LINE__) "): "
 
 #define ABORT(...) _Abort(_ABORT_PREFIX, __VA_ARGS__)
 


### PR DESCRIPTION
I work on Microsoft's C++ Standard Library implementation, where we recently merged microsoft/STL#4405 to remove our internal `_STRINGIZE` macro. Our "Real World Code" test suite, which builds popular open-source projects like yours, found that you were using this MSVC-internal macro and therefore our change broke your code.

The C++ Standard's rule is that `_Leading_underscore_capital` identifiers (including `_LEADING_UNDERSCORE_ALL_CAPS`) are reserved for the compiler and Standard Library, so other libraries and applications should avoid using such reserved identifiers. This is [N4971](https://isocpp.org/files/papers/N4971.pdf) 5.10 \[lex.name\]/3:

> In addition, some identifiers appearing as a *token* or *preprocessing-token* are reserved for use by C++ implementations and shall not be used otherwise; no diagnostic is required.
> — Each identifier that contains a double underscore `__` or begins with an underscore followed by an uppercase letter is reserved to the implementation for any use.

Fortunately, your usage was very limited and you already had a fallback for non-MSVC platforms, so it's simple to rename the affected macros.

Related PR: 3rdparty/stout#72