### PR TITLE
[ebpf] Introduces eBPF header and source.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,6 +306,7 @@ set(LINUX_SRC
   linux/ns.cpp
   linux/perf.cpp
   linux/systemd.cpp
+  linux/ebpf.cpp
   slave/containerizer/mesos/linux_launcher.cpp
   slave/containerizer/mesos/isolators/appc/runtime.cpp
   slave/containerizer/mesos/isolators/cgroups/cgroups.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1403,6 +1403,8 @@ MESOS_LINUX_FILES =									\
   linux/sched.hpp									\
   linux/systemd.cpp									\
   linux/systemd.hpp									\
+  linux/ebpf.cpp              \
+  linux/ebpf.hpp              \
   slave/containerizer/mesos/linux_launcher.cpp						\
   slave/containerizer/mesos/linux_launcher.hpp						\
   slave/containerizer/mesos/isolators/appc/runtime.cpp					\

--- a/src/linux/ebpf.cpp
+++ b/src/linux/ebpf.cpp
@@ -1,0 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "linux/ebpf.hpp"

--- a/src/linux/ebpf.hpp
+++ b/src/linux/ebpf.hpp
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __EBPF_HPP__
+#define __EBPF_HPP__
+
+#endif // __EBPF_HPP__


### PR DESCRIPTION
The cgroups v2 Device Controller uses eBPF to manage devices permissions. Hence, Mesos needs a small library for interacting the Linux eBPF API.

More information:
- https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#device-controller