### PR TITLE
[cgroups2] Check if a list of subsystems are available to a cgroup.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include <stout/foreach.hpp>
 #include <stout/os.hpp>
 #include <stout/path.hpp>
 #include <stout/stringify.hpp>
@@ -278,6 +279,26 @@ Try<set<string>> available(const string& cgroup)
   return set<string>(
       std::make_move_iterator(subsystems.begin()),
       std::make_move_iterator(subsystems.end()));
+}
+
+
+Try<bool> available(const string& cgroup, const vector<string>& subsystems)
+{
+  Try<set<string>> available = controllers::available(cgroup);
+  if (available.isError()) {
+    return Error(
+        "Failed to determine the available subsystems for the cgroup '" +
+        cgroup + "': " + available.error());
+  }
+
+  foreach (const string& subsystem, subsystems) {
+    if (available.get().find(subsystem) == available.get().end()) {
+      // `subsystem` was not found.
+      return false;
+    }
+  }
+
+  return true;
 }
 
 

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -53,6 +53,11 @@ namespace subsystems {
 // on the host.
 Try<std::set<std::string>> available(const std::string& cgroup);
 
+// Check if a list of subsystems can be enabled by a cgroup.
+Try<bool> available(
+    const std::string& cgroup,
+    const std::vector<std::string>& subsystems);
+
 // Enables the given subsystems in the cgroup and disables all other subsystems.
 // Errors if a requested subsystem is not available.
 Try<Nothing> enable(


### PR DESCRIPTION
Introduces a utility to check if a list of subsystems can be enabled by a provided cgroup. This is equivalent to checking if the subsystems are listed the cgroup's "cgroup.controllers" file.