### PR TITLE
[cgroups2] Rename all 'subsystems' to 'controllers'.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -72,27 +72,6 @@ const std::string TYPE = "cgroup.type";
 
 } // namespace control {
 
-namespace controllers {
-
-// Find the available controllers (AKA subsystems) in the provided cgroup.
-Try<set<string>> available(const string& cgroup)
-{
-  Try<string> read =
-    cgroups2::read(cgroup, cgroups2::control::CONTROLLERS);
-
-  if (read.isError()) {
-    return Error("Failed to read cgroup.controllers: " + read.error());
-  }
-
-  vector<string> subsystems = strings::split(*read, " ");
-  return set<string>(
-      std::make_move_iterator(subsystems.begin()),
-      std::make_move_iterator(subsystems.end()));
-}
-
-} // namespace controllers {
-
-
 namespace subtree_control {
 
 struct State
@@ -101,44 +80,44 @@ struct State
 
   // We don't return errors here because enabling something
   // unknown will fail when writing it back out.
-  void enable(const vector<string>& subsystems)
+  void enable(const vector<string>& controllers)
   {
-    foreach (const string& subsystem, subsystems) {
-      enable(subsystem);
+    foreach (const string& controller, controllers) {
+      enable(controller);
     }
   }
 
   // We don't return errors here because enabling something
   // unknown will fail when writing it back out.
-  void enable(const string& subsystem)
+  void enable(const string& controller)
   {
-    _disabled.erase(subsystem);
-    _enabled.insert(subsystem);
+    _disabled.erase(controller);
+    _enabled.insert(controller);
   }
 
   // We don't return errors here since disabling something
   // unknown will fail when writing it back out.
-  void disable(const string& subsystem)
+  void disable(const string& controller)
   {
-    _enabled.erase(subsystem);
-    _disabled.insert(subsystem);
+    _enabled.erase(controller);
+    _disabled.insert(controller);
   }
 
   set<string> enabled()  const { return _enabled; }
   set<string> disabled() const { return _disabled; }
 
-  bool enabled(const string& subsystem) const
+  bool enabled(const string& controller) const
   {
-    return _enabled.find(subsystem) != _enabled.end();
+    return _enabled.find(controller) != _enabled.end();
   }
 
   static State parse(const string& contents)
   {
     State control;
-    vector<string> subsystems = strings::split(contents, " ");
+    vector<string> controllers = strings::split(contents, " ");
     control._enabled.insert(
-      std::make_move_iterator(subsystems.begin()),
-      std::make_move_iterator(subsystems.end()));
+      std::make_move_iterator(controllers.begin()),
+      std::make_move_iterator(controllers.end()));
     return control;
   }
 
@@ -263,7 +242,7 @@ Try<Nothing> unmount()
   return Nothing();
 }
 
-namespace subsystems {
+namespace controllers {
 
 Try<set<string>> available(const string& cgroup)
 {
@@ -274,14 +253,14 @@ Try<set<string>> available(const string& cgroup)
                  + contents.error());
   }
 
-  vector<string> subsystems = strings::split(*contents, " ");
+  vector<string> controllers = strings::split(*contents, " ");
   return set<string>(
-      std::make_move_iterator(subsystems.begin()),
-      std::make_move_iterator(subsystems.end()));
+      std::make_move_iterator(controllers.begin()),
+      std::make_move_iterator(controllers.end()));
 }
 
 
-Try<Nothing> enable(const string& cgroup, const vector<string>& subsystems)
+Try<Nothing> enable(const string& cgroup, const vector<string>& controllers)
 {
   Try<string> contents =
     cgroups2::read(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
@@ -291,12 +270,12 @@ Try<Nothing> enable(const string& cgroup, const vector<string>& subsystems)
   }
 
   subtree_control::State control = subtree_control::State::parse(*contents);
-  control.enable(subsystems);
+  control.enable(controllers);
   return cgroups2::write(
       cgroup,
       control::SUBTREE_CONTROLLERS,
       stringify(control));
 }
 
-} // namespace subsystems {
+} // namespace controllers {
 } // namespace cgroups2 {

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -46,20 +46,20 @@ Try<bool> mounted();
 // responsibility of the caller to ensure all child cgroups have been destroyed.
 Try<Nothing> unmount();
 
-namespace subsystems {
+namespace controllers {
 
-// Gets the subsystems that can be controlled by the provided cgroup.
-// Providing cgroups2::ROOT_CGROUP will yield the set of subsystems available
+// Gets the controllers that can be controlled by the provided cgroup.
+// Providing cgroups2::ROOT_CGROUP will yield the set of controllers available
 // on the host.
 Try<std::set<std::string>> available(const std::string& cgroup);
 
-// Enables the given subsystems in the cgroup and disables all other subsystems.
-// Errors if a requested subsystem is not available.
+// Enables the given controllers in the cgroup and disables all other
+// controllers. Errors if a requested controller is not available.
 Try<Nothing> enable(
     const std::string& cgroup,
-    const std::vector<std::string>& subsystems);
+    const std::vector<std::string>& controllers);
 
-} // namespace subsystems {
+} // namespace controllers {
 } // namespace cgroups2
 
 #endif // __CGROUPS_V2_HPP__


### PR DESCRIPTION
In cgroups v1, the both "subsystem" AND "controller" are used to refer to the cgroups controllers, e.g. "cpu", "memory", etc.

In cgroups v2, ONLY "controller" is used. Our codebase uses both names, but going forward with cgroups v2 we will only be using "controllers". Hence, this patch which renames instances of "subsystem(s)" to "controller(s)".