### PR TITLE
[cgroups2] Adds cgroups2::controllers::enabled() to obtain the set of enabled controllers.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -278,6 +278,22 @@ Try<Nothing> enable(const string& cgroup, const vector<string>& controllers)
       stringify(control));
 }
 
+
+Try<set<string>> enabled(const string& cgroup)
+{
+  Try<string> contents =
+    cgroups2::read(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
+  if (contents.isError()) {
+    return Error(
+        "Failed to read 'cgroup.subtree_control' in '" + cgroup + "': " +
+        contents.error());
+  }
+
+  using State = control::subtree_control::State;
+  State control = State::parse(*contents);
+  return control.enabled();
+}
+
 } // namespace controllers {
 
 } // namespace cgroups2 {

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -63,6 +63,10 @@ Try<Nothing> enable(
     const std::string& cgroup,
     const std::vector<std::string>& controllers);
 
+
+// Get all the controllers that are enabled for a cgroup.
+Try<std::set<std::string>> enabled(const std::string& cgroup);
+
 } // namespace controllers {
 
 } // namespace cgroups2 {


### PR DESCRIPTION
```cpp
// Get all the controllers that are enabled for a cgroup.
Try<std::set<std::string>> enabled(const std::string& cgroup);
```