### PR TITLE
[ebpf][cgroups2] Detach eBPF BPF_CGROUP_DEVICE programs by id.

### DIFF
--- a/src/linux/ebpf.hpp
+++ b/src/linux/ebpf.hpp
@@ -61,6 +61,15 @@ namespace cgroups2 {
 // device access dynamically.
 Try<Nothing> attach(int fd, const std::string& cgroup);
 
+// Detach a BPF_CGROUP_DEVICE eBPF program from a cgroup, by program id.
+// @param    cgroup       Absolute path of a cgroup.
+// @param    program_id   Id of the eBPF program to detach.
+Try<Nothing> detach(const std::string& cgroup, uint32_t program_id);
+
+// Get the program ids of all programs that have been attached to a cgroup.
+// @param    cgroup   Absolute path of a cgroup.
+Try<std::vector<uint32_t>> attached(const std::string& cgroup);
+
 } // namespace cgroups2 {
 
 


### PR DESCRIPTION
Removing programs that are attached to a cgroup is a three step process.
1. Fetch the program ids that are attached to the cgroup.
2. Fetch the file descriptors of the attached programs, using their program ids.
3. Use the file descriptors of the attached programs to detach them.

This patch adds the function `ebpf::cgroups2::detach` to carry out the second and third steps.