### PR TITLE
[ebpf][cgroups2] Update ebpf::cgroups2::attach() to load and attach.

### DIFF
--- a/src/linux/ebpf.cpp
+++ b/src/linux/ebpf.cpp
@@ -65,6 +65,8 @@ void Program::append(vector<bpf_insn>&& instructions)
 }
 
 
+// Load an eBPF program into the kernel and return the file
+// descriptor of the loaded program.
 Try<int> load(const Program& program)
 {
   bpf_attr attribute;
@@ -101,7 +103,12 @@ Try<int> load(const Program& program)
 
 namespace cgroups2 {
 
-Try<Nothing> attach(int fd, const string& cgroup)
+// Attaches the eBPF program identified by the provided fd to a cgroup.
+//
+// TODO(dleamy): This currently does not replace existing programs attached
+// to the cgroup, we will need to add replacement to support adding / removing
+// device access dynamically.
+Try<Nothing> attach(const string& cgroup, int fd)
 {
   Try<int> cgroup_fd = os::open(cgroup, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
   if (cgroup_fd.isError()) {
@@ -147,6 +154,24 @@ Try<Nothing> attach(int fd, const string& cgroup)
     return Error("BPF program attach syscall failed: "
                  + result.error().message);
   }
+
+  return Nothing();
+}
+
+
+Try<Nothing> attach(const string& cgroup, const Program& program)
+{
+  Try<int> program_fd = ebpf::load(program);
+  if (program_fd.isError()) {
+    return Error("Failed to load eBPF program: " + program_fd.error());
+  }
+
+  Try<Nothing> _attach = attach(cgroup, *program_fd);
+  if (_attach.isError()) {
+    return Error("Failed to attach eBPF program: " + _attach.error());
+  }
+
+  os::close(*program_fd);
 
   return Nothing();
 }

--- a/src/linux/ebpf.hpp
+++ b/src/linux/ebpf.hpp
@@ -54,14 +54,14 @@ Try<int> load(const Program& program);
 
 namespace cgroups2 {
 
-// Attaches the eBPF program identified by the provided fd to a cgroup.
-//
-// TODO(dleamy): This currently does not replace existing programs attached
-// to the cgroup, we will need to add replacement to support adding / removing
-// device access dynamically.
-Try<Nothing> attach(int fd, const std::string& cgroup);
+// Load and attach an BPF_CGROUP_DEVICE eBPF program to a cgroup.
+// @param   cgroup    Absolute path of a cgroup.
+// @param   program   eBPF program to be loaded.
+Try<Nothing> attach(const std::string& cgroup, const Program& program);
 
-// Detach a BPF_CGROUP_DEVICE eBPF program from a cgroup, by program id.
+// Detach an BPF_CGROUP_DEVICE eBPF program from a cgroup, by program id.
+// @param    cgroup       Absolute path of a cgroup.
+// @param    program_id   Id of the eBPF program to detach.
 Try<Nothing> detach(const std::string& cgroup, uint32_t program_id);
 
 // Get the program ids of all programs that have been attached to a cgroup.


### PR DESCRIPTION
Correctly handling eBPF file descriptors requires some subtle knowledge about how loading and unloading eBPF programs works.

Specifically, to unload an eBPF program there cannot be any open file descriptors to the program and the program cannot be attached.

To avoid requiring users of the API to know that the file descriptor returned by `ebpf::load()` needs to be closed before the loaded program can be detached, we remove `ebpf::load()` from the public interface and update `ebpf::cgroups2::load()` to:
  1. Load a program,
  2. attach the program, and
  3. close the loaded program's file descriptor, so detaching it will unload it.