### PR TITLE
[cgroups2] FIX: Updated `subsystems` namespace to, new, `controllers`…

### DIFF
--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -48,7 +48,7 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_AvailableSubsystems)
     ASSERT_SOME(cgroups2::mount());
   }
 
-  Try<set<string>> available = cgroups2::subsystems::available(
+  Try<set<string>> available = cgroups2::controllers::available(
     cgroups2::ROOT_CGROUP);
 
   ASSERT_SOME(available);


### PR DESCRIPTION
… namespace, in tests.

The commit 35ecb9a, which renamed `subsystems` to `controllers` missed this one instance, inside of the tests.