### PR TITLE
[cgroups2][ebpf] Addresses formatting inconsistences.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -102,6 +102,7 @@ struct State
   }
 
   set<string> enabled()  const { return _enabled; }
+
   set<string> disabled() const { return _disabled; }
 
   bool enabled(const string& controller) const
@@ -279,4 +280,5 @@ Try<Nothing> enable(const string& cgroup, const vector<string>& controllers)
 }
 
 } // namespace controllers {
+
 } // namespace cgroups2 {

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -33,13 +33,16 @@ const std::string ROOT_CGROUP = "";
 // Checks if cgroups2 is available on the system.
 bool enabled();
 
+
 // Mounts the cgroups2 file system at /sys/fs/cgroup. Errors if
 // the cgroups v2 file system is already mounted.
 Try<Nothing> mount();
 
+
 // Checks if the cgroup2 file systems is mounted at /sys/fs/cgroup,
 // returns an error if the mount is found at an unexpected location.
 Try<bool> mounted();
+
 
 // Unmounts the cgroups2 file system from /sys/fs/cgroup. Errors if
 // the cgroup2 file system is not mounted at /sys/fs/cgroup. It's the
@@ -53,6 +56,7 @@ namespace controllers {
 // on the host.
 Try<std::set<std::string>> available(const std::string& cgroup);
 
+
 // Enables the given controllers in the cgroup and disables all other
 // controllers. Errors if a requested controller is not available.
 Try<Nothing> enable(
@@ -60,6 +64,7 @@ Try<Nothing> enable(
     const std::vector<std::string>& controllers);
 
 } // namespace controllers {
-} // namespace cgroups2
+
+} // namespace cgroups2 {
 
 #endif // __CGROUPS_V2_HPP__

--- a/src/linux/ebpf.hpp
+++ b/src/linux/ebpf.hpp
@@ -52,8 +52,10 @@ namespace cgroups2 {
 // Load and attach a BPF_CGROUP_DEVICE eBPF program to a cgroup.
 Try<Nothing> attach(const std::string& cgroup, const Program& program);
 
+
 // Detach a BPF_CGROUP_DEVICE eBPF program from a cgroup, by program id.
 Try<Nothing> detach(const std::string& cgroup, uint32_t program_id);
+
 
 // Get the program ids of all programs that have been attached to a cgroup.
 Try<std::vector<uint32_t>> attached(const std::string& cgroup);

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -60,6 +60,8 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_AvailableSubsystems)
 }
 
 } // namespace tests {
+
 } // namespace internal {
+
 } // namespace mesos {
 


### PR DESCRIPTION
- Two free lines between functions.
- One free line between ending namespaces.
- One free line between methods.
- Ending namespace having format `} // namespace <name> {`.