### PR TITLE
Revert "Enable verbose logging for Maven."

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2100,7 +2100,7 @@ if HAS_JAVA
 $(MESOS_JAR): $(MESOS_JAR_SOURCE) $(MESOS_JAR_GENERATED) java/mesos.pom
 	@echo "Building mesos-$(PACKAGE_VERSION).jar ..."
 	@cd $(abs_top_builddir)/src/java &&  \
-	  env JAVA_HOME=$(JAVA_HOME) $(MVN) -X -B -q -f mesos.pom clean package
+	  env JAVA_HOME=$(JAVA_HOME) $(MVN) -B -q -f mesos.pom clean package
 
 # Convenience library for JNI bindings.
 # TODO(Charles Reiss): We really should be building the Java library
@@ -2215,7 +2215,7 @@ $(EXAMPLES_JAR): $(EXAMPLES_SOURCE)
 CLEANFILES += $(EXAMPLES_JAR)
 
 maven-install: $(MESOS_JAR) java/mesos.pom
-	env JAVA_HOME=$(JAVA_HOME) $(MVN) -X -B -q -f java/mesos.pom install
+	env JAVA_HOME=$(JAVA_HOME) $(MVN) -B -q -f java/mesos.pom install
 
 PHONY_TARGETS += maven-install
 endif # HAS_JAVA


### PR DESCRIPTION
Verbose Maven logging creates massive log outputs. They were useful for debugging but given the size of the logs it's not prudent to have them enabled by default.