### PR TITLE
[mesos-tidy] Fix broken Dockerfile due to llvm repo move.

### DIFF
--- a/support/mesos-tidy/Dockerfile
+++ b/support/mesos-tidy/Dockerfile
@@ -39,11 +39,11 @@ RUN curl -sSL https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.sh \
     sh /tmp/install-cmake.sh --skip-license --prefix=/usr/local
 
 RUN \
-  git clone --depth 1 -b release_90 http://llvm.org/git/llvm /tmp/llvm && \
-  git clone --depth 1 -b mesos_90 http://github.com/mesos/clang.git /tmp/llvm/tools/clang && \
-  git clone --depth 1 -b mesos_90 http://github.com/mesos/clang-tools-extra.git /tmp/llvm/tools/clang/tools/extra && \
+  git clone --depth 1 -b release/9.x http://github.com/llvm/llvm-project.git /tmp/llvm-project && \
+  git clone --depth 1 -b mesos_90 http://github.com/mesos/clang.git /tmp/llvm-project/llvm/tools/clang && \
+  git clone --depth 1 -b mesos_90 http://github.com/mesos/clang-tools-extra.git /tmp/llvm-project/llvm/tools/clang/tools/extra && \
   \
-  cmake /tmp/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt && \
+  cmake /tmp/llvm-project/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt && \
   cmake --build tools/clang/lib/Headers --target install -- -j $(nproc) && \
   cmake --build tools/clang/tools/extra/clang-tidy --target install -- -j $(nproc) && \
   \

--- a/support/mesos-tidy/README.md
+++ b/support/mesos-tidy/README.md
@@ -14,10 +14,15 @@ Building the image involves compiling a Mesos-flavored version of
 `clang-tidy`, installing Mesos dependencies, and installation of tools
 to drive check invocations.
 
-The image can be built with
-
+The image can be built with:
 ```bash
 $ docker build -t mesos-tidy .
+```
+
+On an M1 Mac, you may need to pass `--platform` to avoid an error with
+`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory`:
+```bash
+$ docker build -t mesos-tidy --platform linux/amd64 .
 ```
 
 A pre-built image is available via Docker Hub as `mesos/mesos-tidy`.
@@ -28,11 +33,19 @@ To run checks over a Mesos checkout invoke
 
 ```bash
 $ docker run \
+      --platform linux/amd64 \
       --rm \
       -v <MESOS_CHECKOUT>:/SRC \
       [-e CHECKS=<CHECKS>] \
       [-e CMAKE_ARGS=<CMAKE_ARGS>] \
       mesos-tidy
+```
+
+If running on macOS, it will run out of memory by default and you need
+to constrain the JOB count, for example:
+
+```bash
+docker run --rm -v <MESOS_CHECKOUT>:/SRC --platform linux/amd64 --env JOBS=4 --memory 32GB mesos-tidy
 ```
 
 Here `MESOS_CHECKOUT` points to a git checkout of the Mesos source tree.


### PR DESCRIPTION
This appears to fix the mesos-tidy docker image build, which now works per the readme instructions:

```
$ docker build -t mesos-tidy .
```

Running the image was hitting gcc internal errors due to OOMs, which I fixed via the updates shown in the readme.