### PR TITLE
[cgroups2] Introduces cgroups2::create() to create new cgroups.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -242,6 +242,23 @@ Try<Nothing> unmount()
   return Nothing();
 }
 
+
+Try<Nothing> create(const string& cgroup, bool recursive)
+{
+  string absolutePath = path::join(MOUNT_POINT, cgroup);
+  if (os::exists(absolutePath)) {
+    return Error("A cgroup at '" + absolutePath + "' already exists");
+  }
+
+  Try<Nothing> mkdir = os::mkdir(absolutePath, recursive);
+  if (mkdir.isError()) {
+    return Error(
+      "Failed to create directory '" + absolutePath + "': " + mkdir.error());
+  }
+
+  return Nothing();
+}
+
 namespace controllers {
 
 Try<set<string>> available(const string& cgroup)

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -49,6 +49,13 @@ Try<bool> mounted();
 // responsibility of the caller to ensure all child cgroups have been destroyed.
 Try<Nothing> unmount();
 
+
+// Creates a cgroup off of the base hierarchy, i.e. /sys/fs/cgroup/<cgroup>.
+// cgroup can be a nested cgroup (e.g. foo/bar/baz). If cgroup is a nested
+// cgroup and the parent cgroups do not exist, an error will be returned unless
+// recursive=true.
+Try<Nothing> create(const std::string& cgroup, bool recursive = false);
+
 namespace controllers {
 
 // Gets the controllers that can be controlled by the provided cgroup.


### PR DESCRIPTION
Adds `cgroups2::create` to the cgroups2 API, allowing new cgroups to be created.