### PR TITLE
[cgroups2] Introduced cgroups2::destroy() to remove a cgroup.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -256,6 +256,23 @@ Try<Nothing> create(const string& cgroup, bool recursive)
   return Nothing();
 }
 
+
+Try<Nothing> destroy(const string& cgroup)
+{
+  string absolutePath = path::join(MOUNT_POINT, cgroup);
+  if (!os::exists(absolutePath)) {
+    return Error("There does not exist a cgroup at '" + absolutePath + "'");
+  }
+
+  Try<Nothing> rmdir = os::rmdir(absolutePath);
+  if (rmdir.isError()) {
+    return Error(
+      "Failed to remove directory '" + absolutePath + "': " + rmdir.error());
+  }
+
+  return Nothing();
+}
+
 namespace controllers {
 
 Try<set<string>> available(const string& cgroup)

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -56,6 +56,11 @@ Try<Nothing> unmount();
 // recursive=true.
 Try<Nothing> create(const std::string& cgroup, bool recursive = false);
 
+
+// Destroy a cgroup. If the cgroup does not exist or cannot be destroyed,
+// e.g. because it contains processes, an error is returned.
+Try<Nothing> destroy(const std::string& cgroup);
+
 namespace controllers {
 
 // Gets the controllers that can be controlled by the provided cgroup.


### PR DESCRIPTION
Adds `cgroups2::destroy()` to destroy cgroups.

Returns an error if the provided cgroup:
- Does not exist.
- Has child processes, or otherwise can't be destroyed.