### PR TITLE
[cgroups2] Introduces the cpu namespace and cpu::weight() API

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -382,4 +382,22 @@ Try<set<string>> enabled(const string& cgroup)
 
 } // namespace controllers {
 
+namespace cpu {
+
+namespace control {
+
+const std::string IDLE = "cpu.idle";
+const std::string MAX = "cpu.max";
+const std::string MAX_BURST = "cpu.max.burst";
+const std::string PRESSURE = "cpu.pressure";
+const std::string STATS = "cpu.stat";
+const std::string UCLAMP_MAX = "cpu.uclamp.max";
+const std::string UCLAMP_MIN = "cpu.uclamp.min";
+const std::string WEIGHT = "cpu.weight";
+const std::string WEIGHT_NICE = "cpu.weight.nice";
+
+} // namespace control {
+
+} // namespace cpu {
+
 } // namespace cgroups2 {

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -95,6 +95,19 @@ Try<std::set<std::string>> enabled(const std::string& cgroup);
 
 } // namespace controllers {
 
+namespace cpu {
+
+// Set the weight for a cgroup.
+// Cannot be used for the root cgroup.
+Try<Nothing> weight(const std::string& cgroup, uint32_t weight);
+
+
+// Determine the weight a cgroup.
+// Cannot be used for the root cgroup.
+Try<uint32_t> weight(const std::string& cgroup);
+
+} // namespace cpu {
+
 } // namespace cgroups2 {
 
 #endif // __CGROUPS_V2_HPP__


### PR DESCRIPTION
Introduces the `cpu` namespace for cgroups2, and expose an API to set
the CPU weight for a cgroup.

In cgroups v2, CPU cycles are allocated based on weights that are assigned
to cgroups, using the "cpu.weight" control. Specifically, a cgroup has access
to 100(weight/total_weight)% of CPU access.