### PR TITLE
[cgroups2] Introduces API to move a process into a cgroup, by PID.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -61,6 +61,15 @@ Try<Nothing> create(const std::string& cgroup, bool recursive = false);
 // e.g. because it contains processes, an error is returned.
 Try<Nothing> destroy(const std::string& cgroup);
 
+
+// Moves a process into a cgroup, by PID. Errors if the cgroup does not exist.
+// If the process is already in the cgroup, this operation is a NOP.
+Try<Nothing> move_process(const std::string& cgroup, pid_t pid);
+
+
+// Get the cgroup that a process is part of.
+Try<std::string> cgroup(pid_t pid);
+
 namespace controllers {
 
 // Gets the controllers that can be controlled by the provided cgroup.


### PR DESCRIPTION
A process can be moved into a cgroup by writing its process id into
the cgroup's `cgroup.procs` file. When a process is moved, all its
threads move with it.

In this PR we introduce `cgroups2::move_process` to add a process to
a cgroup, `cgroups2::cgroup` to check which cgroup a process is a
member of, and test the introduced functionality.