### PR TITLE
[cgroups2] Use rmdir instead of rm -rf to delete a cgroup.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -265,7 +265,7 @@ Try<Nothing> destroy(const string& cgroup)
     return Error("There does not exist a cgroup at '" + absolutePath + "'");
   }
 
-  Try<Nothing> rmdir = os::rmdir(absolutePath);
+  Try<Nothing> rmdir = os::rmdir(absolutePath, false);
   if (rmdir.isError()) {
     return Error("Failed to remove directory '" + absolutePath + "': "
                  + rmdir.error());


### PR DESCRIPTION
Even with `sudo` permissions, `rm -rf` fails with "Operation not permitted" when deleting a directory inside of `/sys/fs/cgroup`. On the other hand, `sudo rmdir` does not fail.

`os::rmdir` uses `rm -rf` when `recursive=true` and `rmdir` when `recursive=false`. Hence, we set `recursive=false` so cgroups can be removed.