### PR TITLE
[cgroups2] Introduces cgroups2::exists to check if a cgroup exists.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -243,6 +243,12 @@ Try<Nothing> unmount()
 }
 
 
+bool exists(const string& cgroup)
+{
+  return os::exists(path::join(MOUNT_POINT, cgroup));
+}
+
+
 Try<Nothing> create(const string& cgroup, bool recursive)
 {
   const string absolutePath = path::join(MOUNT_POINT, cgroup);
@@ -259,12 +265,11 @@ Try<Nothing> create(const string& cgroup, bool recursive)
 
 Try<Nothing> destroy(const string& cgroup)
 {
-  const string absolutePath = path::join(MOUNT_POINT, cgroup);
-
-  if (!os::exists(absolutePath)) {
-    return Error("There does not exist a cgroup at '" + absolutePath + "'");
+  if (!cgroups2::exists(cgroup)) {
+    return Error("Cgroup '" + cgroup + "' does not exist");
   }
 
+  const string absolutePath = path::join(MOUNT_POINT, cgroup);
   Try<Nothing> rmdir = os::rmdir(absolutePath, false);
   if (rmdir.isError()) {
     return Error("Failed to remove directory '" + absolutePath + "': "

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -50,6 +50,10 @@ Try<bool> mounted();
 Try<Nothing> unmount();
 
 
+// Check if a cgroup exists.
+bool exists(const std::string& cgroup);
+
+
 // Creates a cgroup off of the base hierarchy, i.e. /sys/fs/cgroup/<cgroup>.
 // cgroup can be a nested cgroup (e.g. foo/bar/baz). If cgroup is a nested
 // cgroup and the parent cgroups do not exist, an error will be returned unless


### PR DESCRIPTION
If you call `cgroups2::destroy` on a cgroup that does not exist, it will throw an error. This is expected. However, it means that the caller needs to know whether a cgroup exists. This PR introduces `cgroups2::exists`, allowing the caller find out if a cgroup exists.

This is useful, for example, for test fixtures where cgroups from a previous run of a test may or may not be cleaned up, depending on whether or not the test was successful.