### PR TITLE
[cgroups2] Convert cgroups2::read/write to template functions.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -44,15 +44,6 @@ const string FILE_SYSTEM = "cgroup2";
 // Mount point for the cgroups2 file system.
 const string MOUNT_POINT = "/sys/fs/cgroup";
 
-// Forward declaration.
-Try<string> read(const string& cgroup, const string& control);
-
-// Forward declaration.
-Try<Nothing> write(
-    const string& cgroup,
-    const string& control,
-    const string& value);
-
 namespace control {
 
 // Interface files found in all cgroups.
@@ -141,16 +132,18 @@ std::ostream& operator<<(std::ostream& stream, const State& state)
 } // namespace control {
 
 
+template <>
 Try<string> read(const string& cgroup, const string& control)
 {
   return os::read(path::join(cgroups2::MOUNT_POINT, cgroup, control));
 }
 
 
+template <>
 Try<Nothing> write(
-  const string& cgroup,
-  const string& control,
-  const string& value)
+    const string& cgroup,
+    const string& control,
+    const string& value)
 {
   return os::write(path::join(cgroups2::MOUNT_POINT, cgroup, control), value);
 }
@@ -278,7 +271,8 @@ namespace controllers {
 
 Try<set<string>> available(const string& cgroup)
 {
-  Try<string> contents = cgroups2::read(cgroup, cgroups2::control::CONTROLLERS);
+  Try<string> contents =
+    cgroups2::read<string>(cgroup, cgroups2::control::CONTROLLERS);
 
   if (contents.isError()) {
     return Error("Failed to read cgroup.controllers in '" + cgroup + "': "
@@ -295,7 +289,7 @@ Try<set<string>> available(const string& cgroup)
 Try<Nothing> enable(const string& cgroup, const vector<string>& controllers)
 {
   Try<string> contents =
-    cgroups2::read(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
+    cgroups2::read<string>(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
 
   if (contents.isError()) {
     return Error(contents.error());
@@ -304,17 +298,15 @@ Try<Nothing> enable(const string& cgroup, const vector<string>& controllers)
   using State = control::subtree_control::State;
   State control = State::parse(*contents);
   control.enable(controllers);
-  return cgroups2::write(
-      cgroup,
-      control::SUBTREE_CONTROLLERS,
-      stringify(control));
+  return cgroups2::write<string>(
+      cgroup, control::SUBTREE_CONTROLLERS, stringify(control));
 }
 
 
 Try<set<string>> enabled(const string& cgroup)
 {
   Try<string> contents =
-    cgroups2::read(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
+    cgroups2::read<string>(cgroup, cgroups2::control::SUBTREE_CONTROLLERS);
   if (contents.isError()) {
     return Error("Failed to read 'cgroup.subtree_control' in '" + cgroup + "'"
                  ": " + contents.error());

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -19,12 +19,24 @@
 
 #include <set>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <stout/nothing.hpp>
 #include <stout/try.hpp>
 
 namespace cgroups2 {
+
+template <typename T>
+static Try<T> read(const std::string& cgroup, const std::string& control);
+
+
+template <typename T>
+static Try<Nothing> write(
+    const std::string& cgroup,
+    const std::string& control,
+    const T& value);
+
 
 // Root cgroup in the cgroup v2 hierarchy. Since the root cgroup has the same
 // path as the root mount point its relative path is the empty string.


### PR DESCRIPTION
To allow overloading of `read` by return type alone, we define `cgroups::read` as a template function. For consistency, we do the same for `cgroups::write`.