### PR TITLE
Removed `-k` option when installing Ruby

### DIFF
--- a/support/mesos-website/Dockerfile
+++ b/support/mesos-website/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
 # Install ruby version manager to get a more updated ruby version                                
 RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - && \
     curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - && \ 
-    curl -k -sSL https://get.rvm.io | bash -s stable --ruby=2.6.6 
+    curl -sSL https://get.rvm.io | bash -s stable --ruby=2.6.6 
 
 ENV PATH=/usr/local/rvm/rubies/ruby-2.6.6/bin:$PATH    
 


### PR DESCRIPTION
Remove the `-k` option to enable CURL's TLS verification when installing Ruby.

I have verified this change in my local env which works well, the Docker image can be built successfully.

```
$ docker build .
[+] Building 90.6s (9/9) FINISHED                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.10kB                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/mesos/mesos-build:ubuntu-16.04                                                                                                                                       4.4s
 => [internal] load .dockerignore                                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                                 0.0s
 => [1/5] FROM docker.io/mesos/mesos-build:ubuntu-16.04@sha256:fa967cbcfb44f55708a3cbc87f245c6d29dd891464db558af56a03ee321526bb                                                                                33.3s
 => => resolve docker.io/mesos/mesos-build:ubuntu-16.04@sha256:fa967cbcfb44f55708a3cbc87f245c6d29dd891464db558af56a03ee321526bb                                                                                 0.0s
 => => sha256:0addb6fece630456e0ab187b0aa4304d0851ba60576e7f6f9042a97ee908a796 851B / 851B                                                                                                                      1.1s
 => => sha256:e895c0531b9a9a288fabe479a49f7059aed83645351ac99ec2ea2616822c9f97 5.97kB / 5.97kB                                                                                                                  0.0s
 => => sha256:78e58219b215b359fe002f0ca1f416617b75ca9b36cb274c98d7a5f808711179 620B / 620B                                                                                                                      1.1s
 => => sha256:fa967cbcfb44f55708a3cbc87f245c6d29dd891464db558af56a03ee321526bb 2.62kB / 2.62kB                                                                                                                  0.0s
 => => sha256:18d680d616571900d78ee1c8fff0310f2a2afe39c6ed0ba2651ff667af406c3e 43.35MB / 43.35MB                                                                                                                4.5s
 => => sha256:eb6959a66df2ea26a26452ba11f84fb64bb45af90204374862ec71ee59f795e7 169B / 169B                                                                                                                      1.4s
 => => sha256:1105027a5560ad2bd3d591eb199d3d895947d4a7dfd6c7e0a00255e65d267f34 404.32MB / 404.32MB                                                                                                             16.7s
 => => sha256:c36946130a385c50ba90c36e531b1abb7e3ad584e04c976ae07f7250c1f52219 32.86MB / 32.86MB                                                                                                                3.9s
 => => sha256:6a6a5e68faab31969a4f0427f7b6a9d98c3c584011d915666e05c1a233f2c1d1 20.28MB / 20.28MB                                                                                                                5.7s
 => => extracting sha256:18d680d616571900d78ee1c8fff0310f2a2afe39c6ed0ba2651ff667af406c3e                                                                                                                       2.3s
 => => sha256:80e07249924c19736c910f1e38d2ff609590ea852e051f501a310ccf2db17536 3.31kB / 3.31kB                                                                                                                  5.1s
 => => sha256:c4c63e2501db9fa019312164d768eba7c759504e6e9ecb165e0fbfa592a33682 5.32MB / 5.32MB                                                                                                                  6.3s
 => => sha256:668b207c282969abe7ce8a35dae7749f4c5b3c4db94e3cb01c188b2b0d88870d 4.60kB / 4.60kB                                                                                                                  6.4s
 => => sha256:ed76dddad568728f831e5674c0072b545642ebafb7216b4e2d3fb10701c2756e 1.33kB / 1.33kB                                                                                                                  6.9s
 => => extracting sha256:0addb6fece630456e0ab187b0aa4304d0851ba60576e7f6f9042a97ee908a796                                                                                                                       0.0s
 => => extracting sha256:78e58219b215b359fe002f0ca1f416617b75ca9b36cb274c98d7a5f808711179                                                                                                                       0.0s
 => => extracting sha256:eb6959a66df2ea26a26452ba11f84fb64bb45af90204374862ec71ee59f795e7                                                                                                                       0.0s
 => => extracting sha256:1105027a5560ad2bd3d591eb199d3d895947d4a7dfd6c7e0a00255e65d267f34                                                                                                                      13.1s
 => => extracting sha256:c36946130a385c50ba90c36e531b1abb7e3ad584e04c976ae07f7250c1f52219                                                                                                                       1.7s
 => => extracting sha256:6a6a5e68faab31969a4f0427f7b6a9d98c3c584011d915666e05c1a233f2c1d1                                                                                                                       1.0s
 => => extracting sha256:80e07249924c19736c910f1e38d2ff609590ea852e051f501a310ccf2db17536                                                                                                                       0.0s
 => => extracting sha256:c4c63e2501db9fa019312164d768eba7c759504e6e9ecb165e0fbfa592a33682                                                                                                                       0.3s
 => => extracting sha256:668b207c282969abe7ce8a35dae7749f4c5b3c4db94e3cb01c188b2b0d88870d                                                                                                                       0.0s
 => => extracting sha256:ed76dddad568728f831e5674c0072b545642ebafb7216b4e2d3fb10701c2756e                                                                                                                       0.0s
 => [2/5] RUN apt-get update &&     apt-get install -y --no-install-recommends       doxygen       locales &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*                                             12.9s
 => [3/5] RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - &&     curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - &&     curl -sSL https://get.rvm.io | bash -s stable --ruby=2.6.6           38.2s 
 => [4/5] RUN locale-gen en_US.UTF-8                                                                                                                                                                            1.0s 
 => [5/5] WORKDIR /mesos                                                                                                                                                                                        0.0s 
 => exporting to image                                                                                                                                                                                          0.6s 
 => => exporting layers                                                                                                                                                                                         0.6s 
 => => writing image sha256:67f6e8eba9e02da475c1cf4208589ac0057810baab172ed2eb19801861c334bb
```