### PR TITLE
[cgroups2] Add cgroups2::path to get the path of a cgroup.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -75,6 +75,10 @@ Try<Nothing> move_process(const std::string& cgroup, pid_t pid);
 // /sys/fs/cgroup. E.g. For /sys/fs/cgroup/test, this will return "test".
 Try<std::string> cgroup(pid_t pid);
 
+
+// Get the absolute of a cgroup. Assumes to cgroup exists.
+std::string path(const std::string& cgroup);
+
 namespace controllers {
 
 // Gets the controllers that can be controlled by the provided cgroup.

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -115,6 +115,14 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_AssignProcessToCgroup)
   AWAIT_EXPECT_WTERMSIG_EQ(SIGKILL, process::reap(pid));
 }
 
+
+TEST_F(Cgroups2Test, CGROUPS2_Path)
+{
+  EXPECT_EQ("/sys/fs/cgroup/", cgroups2::path(cgroups2::ROOT_CGROUP));
+  EXPECT_EQ("/sys/fs/cgroup/foo", cgroups2::path("foo"));
+  EXPECT_EQ("/sys/fs/cgroup/foo/bar", cgroups2::path("foo/bar"));
+}
+
 } // namespace tests {
 
 } // namespace internal {


### PR DESCRIPTION
Introduces a utility to get the absolute path of a cgroup and refactors code to use it.