### PR TITLE
[cgroups2] Introduces an interface to read and assign processes.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -66,14 +66,18 @@ Try<Nothing> create(const std::string& cgroup, bool recursive = false);
 Try<Nothing> destroy(const std::string& cgroup);
 
 
-// Moves a process into a cgroup, by PID. Errors if the cgroup does not exist.
-// If the process is already in the cgroup, this operation is a NOP.
-Try<Nothing> move_process(const std::string& cgroup, pid_t pid);
+// Assign a process to a cgroup, by PID. This removes the process from its
+// current cgroup. Errors if the cgroup does not exist.
+Try<Nothing> assign(const std::string& cgroup, pid_t pid);
 
 
 // Get the cgroup that a process is part of, returns a relative path off of
 // /sys/fs/cgroup. E.g. For /sys/fs/cgroup/test, this will return "test".
 Try<std::string> cgroup(pid_t pid);
+
+
+// Get the processes inside of a cgroup.
+Try<std::set<pid_t>> processes(const std::string& cgroup);
 
 
 // Get the absolute of a cgroup. The cgroup provided should not start with '/'.


### PR DESCRIPTION
`cgroup.procs` lists all of the processes inside of a cgroup, one per line. There may be duplicates. A single process can be moved into a cgroup by writing its process ID into `cgroup.procs`.

Here we introduce:
- Reading the process ids of the processes inside of a cgroup, and
- Assigning a process to a cgroup by process ID.