### PR TITLE
[cgroups2] Added flag to enable cgroups v2.

### DIFF
--- a/cmake/CompilationConfigure.cmake
+++ b/cmake/CompilationConfigure.cmake
@@ -505,6 +505,10 @@ if (LINUX)
       "The XFS disk isolator is not yet supported, see MESOS-9117.")
   endif ()
 
+  option(ENABLE_CGROUPS_V2
+    "Whether to enable cgroups v2."
+    FALSE)
+
   option(ENABLE_LAUNCHER_SEALING
     "Whether to enable containerizer launcher sealing via memfd."
     FALSE)

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,13 @@ AC_ARG_ENABLE([xfs-disk-isolator],
                              [builds the XFS disk isolator]),
               [], [enable_xfs_disk_isolator=no])
 
+# TODO(dleamy): This flag should flipped to --disable-cgroups-v2 so using
+#               cgroups v2 is the default.
+AC_ARG_ENABLE([cgroups-v2],
+              AS_HELP_STRING([--enable-cgroups-v2],
+                             [builds the cgroups2 and ebpf modules]),
+              [], [enable_cgroups_v2=no])
+
 ###############################################################################
 # Optional packages.
 ###############################################################################
@@ -2286,6 +2293,36 @@ Please install the libblkid package for XFS disk isolator support.
 ])
 
 AM_CONDITIONAL([ENABLE_XFS_DISK_ISOLATOR], [test "x$enable_xfs_disk_isolator" = "xyes"])
+
+
+AC_MSG_CHECKING([whether to enable the cgroups v2])
+AS_IF([test "x$enable_cgroups_v2" = "xyes"],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])])
+
+AS_IF([test "x$enable_cgroups_v2" = "xyes"], [
+  # We only support cgroups v2 on Linux.
+  AS_IF([test "$OS_NAME" = "linux"],
+        [],
+        [AC_MSG_ERROR([no cgroups v2 support on $OS_NAME
+-------------------------------------------------------------------
+cgroups v2 is only supported on Linux.
+-------------------------------------------------------------------
+  ])])
+
+  # Check for build dependencies for cgroups v2. We only
+  # enable this if all the needed headers and libraries are present.
+  AC_CHECK_HEADERS([linux/bpf.h],
+                   [], [AC_MSG_ERROR([missing eBPF headers
+-------------------------------------------------------------------
+Please install the bpf Linux kernel headers for cgroups v2 support.
+-------------------------------------------------------------------
+  ])])
+
+  AC_DEFINE([ENABLE_CGROUPS_V2])
+])
+
+AM_CONDITIONAL([ENABLE_CGROUPS_V2], [test "x$enable_cgroups_v2" = "xyes"])
 
 
 # Check if zlib prefix path was provided, and if so, add it to

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -299,14 +299,12 @@ set(INTERNAL_SRC
 set(LINUX_SRC
   linux/capabilities.cpp
   linux/cgroups.cpp
-  linux/cgroups2.cpp
   linux/fs.cpp
   linux/ldcache.cpp
   linux/ldd.cpp
   linux/ns.cpp
   linux/perf.cpp
   linux/systemd.cpp
-  linux/ebpf.cpp
   slave/containerizer/mesos/linux_launcher.cpp
   slave/containerizer/mesos/isolators/appc/runtime.cpp
   slave/containerizer/mesos/isolators/cgroups/cgroups.cpp
@@ -349,6 +347,12 @@ if (ENABLE_XFS_DISK_ISOLATOR)
   list(APPEND LINUX_SRC
     slave/containerizer/mesos/isolators/xfs/disk.cpp
     slave/containerizer/mesos/isolators/xfs/utils.cpp)
+endif ()
+
+if (ENABLE_CGROUPS_v2)
+  list(APPEND LINUX_SRC
+    linux/cgroups2.cpp
+    linux/ebpf.cpp)
 endif ()
 
 if (ENABLE_LAUNCHER_SEALING)
@@ -613,6 +617,7 @@ target_compile_definitions(
   mesos PUBLIC
   USE_CMAKE_BUILD_CONFIG
   $<$<BOOL:${ENABLE_XFS_DISK_ISOLATOR}>:ENABLE_XFS_DISK_ISOLATOR>
+  $<$<BOOL:${ENABLE_CGROUPS_V2}>:ENABLE_CGROUPS_V2>
   $<$<BOOL:${ENABLE_LAUNCHER_SEALING}>:ENABLE_LAUNCHER_SEALING>
   $<$<BOOL:${ENABLE_NVML}>:ENABLE_NVML>
   $<$<BOOL:${ENABLE_PORT_MAPPING_ISOLATOR}>:ENABLE_PORT_MAPPING_ISOLATOR>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1388,8 +1388,6 @@ MESOS_LINUX_FILES =									\
   linux/capabilities.hpp								\
   linux/cgroups.cpp									\
   linux/cgroups.hpp									\
-  linux/cgroups2.cpp									\
-  linux/cgroups2.hpp              \
   linux/fs.cpp										\
   linux/fs.hpp										\
   linux/ldcache.cpp									\
@@ -1403,8 +1401,6 @@ MESOS_LINUX_FILES =									\
   linux/sched.hpp									\
   linux/systemd.cpp									\
   linux/systemd.hpp									\
-  linux/ebpf.cpp              \
-  linux/ebpf.hpp              \
   slave/containerizer/mesos/linux_launcher.cpp						\
   slave/containerizer/mesos/linux_launcher.hpp						\
   slave/containerizer/mesos/isolators/appc/runtime.cpp					\
@@ -1491,6 +1487,14 @@ MESOS_LINUX_FILES +=							\
   slave/containerizer/mesos/isolators/xfs/utils.hpp			\
   slave/containerizer/mesos/isolators/xfs/disk.cpp			\
   slave/containerizer/mesos/isolators/xfs/disk.hpp
+endif
+
+if ENABLE_CGROUPS_V2
+MESOS_LINUX_FILES +=							\
+  linux/cgroups2.cpp      \
+  linux/cgroups2.hpp      \
+  linux/ebpf.cpp      \
+  linux/ebpf.hpp
 endif
 
 if ENABLE_SECCOMP_ISOLATOR
@@ -2820,6 +2824,11 @@ mesos_tests_SOURCES +=						\
   tests/containerizer/xfs_quota_tests.cpp
 endif
 
+if ENABLE_CGROUPS_V2
+mesos_tests_SOURCES +=						\
+  tests/containerizer/cgroups2_tests.cpp
+endif
+
 if ENABLE_SECCOMP_ISOLATOR
 mesos_tests_SOURCES +=						\
   tests/containerizer/linux_seccomp_parser_tests.cpp		\
@@ -2862,7 +2871,6 @@ mesos_tests_SOURCES +=						\
   tests/containerizer/capabilities_test_helper.cpp		\
   tests/containerizer/cgroups_isolator_tests.cpp		\
   tests/containerizer/cgroups_tests.cpp				\
-  tests/containerizer/cgroups2_tests.cpp			\
   tests/containerizer/cni_isolator_tests.cpp			\
   tests/containerizer/docker_volume_isolator_tests.cpp		\
   tests/containerizer/linux_devices_isolator_tests.cpp		\

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -232,7 +232,6 @@ if (LINUX)
     containerizer/capabilities_tests.cpp
     containerizer/cgroups_isolator_tests.cpp
     containerizer/cgroups_tests.cpp
-    containerizer/cgroups2_tests.cpp
     containerizer/cni_isolator_tests.cpp
     containerizer/docker_volume_isolator_tests.cpp
     containerizer/fs_tests.cpp
@@ -256,6 +255,11 @@ if (LINUX)
   if (ENABLE_XFS_DISK_ISOLATOR)
     list(APPEND MESOS_TESTS_SRC
       containerizer/xfs_quota_tests.cpp)
+  endif()
+
+  if (ENABLE_CGROUPS_V2)
+    list(APPEND MESOS_TESTS_SRC
+      containerizer/cgroups2_tests.cpp)
   endif()
 
   if (ENABLE_SECCOMP_ISOLATOR)

--- a/src/tests/environment.cpp
+++ b/src/tests/environment.cpp
@@ -232,7 +232,7 @@ public:
   {
 
     if (matches(test, "CGROUPS2_") || matches(test, "Cgroups2")) {
-#ifdef __linux__
+#if defined(__linux__) && defined(ENABLE_CGROUPS_V2)
       Result<string> user = os::user();
       CHECK_SOME(user);
       return *user != "root" || !cgroups2::enabled();


### PR DESCRIPTION
Cgroups v2 is disabled by default. If `--enable-cgroups-v2` is set, then the cgroups v2 requirements and tests will be added to the build. This includes `src/linux/cgroups2.*` and `src/linux/ebpf.*` and their tests.

We introduce this because older Linux kernel versions do not support cgroups2 but we still want to be able to compile Mesos on them.