### PR TITLE
[cgroups2] Introduce cgroups v2 isolator process.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1494,7 +1494,9 @@ MESOS_LINUX_FILES +=							\
   linux/cgroups2.cpp      \
   linux/cgroups2.hpp      \
   linux/ebpf.cpp      \
-  linux/ebpf.hpp
+  linux/ebpf.hpp      \
+  slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp     \
+  slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
 endif
 
 if ENABLE_SECCOMP_ISOLATOR

--- a/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp"
+
+#include <string>
+
+#include <process/id.hpp>
+
+using mesos::slave::Isolator;
+
+using process::Owned;
+
+using std::string;
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+Cgroups2IsolatorProcess::Cgroups2IsolatorProcess(
+  const hashmap<string, Owned<Subsystem>>& _subsystems)
+  : ProcessBase(process::ID::generate("cgroups2-isolator")),
+    subsystems(_subsystems) {}
+
+
+Cgroups2IsolatorProcess::~Cgroups2IsolatorProcess() {}
+
+
+Try<Isolator*> Cgroups2IsolatorProcess::create(const Flags& flags)
+{
+  hashmap<string, Owned<Subsystem>> subsystems;
+
+  Owned<MesosIsolatorProcess> process(new Cgroups2IsolatorProcess(subsystems));
+  return new MesosIsolator(process);
+}
+
+
+bool Cgroups2IsolatorProcess::supportsNesting()
+{
+  // TODO(dleamy): Update this once cgroups v2 supports nested containers.
+  return false;
+}
+
+
+bool Cgroups2IsolatorProcess::supportsStandalone()
+{
+  return true;
+}
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {

--- a/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __CGROUPS_V2_ISOLATOR_HPP__
+#define __CGROUPS_V2_ISOLATOR_HPP__
+
+#include <string>
+
+#include <process/owned.hpp>
+
+#include <stout/hashmap.hpp>
+#include <stout/hashset.hpp>
+#include <stout/try.hpp>
+
+#include "slave/containerizer/mesos/isolator.hpp"
+#include "slave/containerizer/mesos/isolators/cgroups/subsystem.hpp"
+#include "slave/flags.hpp"
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+class Cgroups2IsolatorProcess : public MesosIsolatorProcess
+{
+public:
+  static Try<mesos::slave::Isolator*> create(const Flags& flags);
+
+  ~Cgroups2IsolatorProcess() override;
+
+  bool supportsNesting() override;
+
+  bool supportsStandalone() override;
+
+private:
+  Cgroups2IsolatorProcess(
+      const hashmap<std::string, process::Owned<Subsystem>>& _subsystems);
+
+  // Maps each subsystems to the `Subsystem` isolator that manages it.
+  const hashmap<std::string, process::Owned<Subsystem>> subsystems;
+};
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {
+
+#endif


### PR DESCRIPTION
Introduces `Cgroups2IsolatorProcess`, a new isolator process which
uses cgroups v2. Cgroups v2 equivalent of `CgroupsIsolatorProcess`.

We introduce a new class, rather than adapting the existing
`CgroupsIsolatorProcess`, because the two isolators need to behave
markedly differently.

Specifically, the v1 isolator:
- Maintains a mapping from the cgroup hierarchy where a controller is
  mounted to the `Subsystem` that manages it.
- Mounts cgroups hierarchies for subsystems, as they are required.
- Performs (virtually) all cgroups operations taking into account which
  hierarchy a subsystem and container is a member of.

all of which are not relevant in the context of cgroup v2's unified
hierarchy.