### PR TITLE
[cgroups2] Added path helpers that define the structure of the cgroup2 filesystem

### DIFF
--- a/src/slave/containerizer/mesos/paths.cpp
+++ b/src/slave/containerizer/mesos/paths.cpp
@@ -654,6 +654,30 @@ Option<ContainerID> parseCgroupPath(
   return current;
 }
 
+namespace cgroups2 {
+
+string agent(const string& root, bool leaf)
+{
+  if (leaf) { return path::join(root, "agent", "leaf"); }
+  else      { return path::join(root, "agent"); }
+}
+
+
+string container(
+    const string& root,
+    const ContainerID& containerId,
+    bool leaf)
+{
+  const string& container = containerizer::paths::buildPath(
+      containerId,
+      CGROUP_SEPARATOR,
+      containerizer::paths::JOIN);
+
+  if (leaf) { return path::join(root, container, "leaf"); }
+  else      { return path::join(root, container);}
+}
+
+} // namespace cgroups2 {
 } // namespace paths {
 } // namespace containerizer {
 } // namespace slave {

--- a/src/slave/containerizer/mesos/paths.hpp
+++ b/src/slave/containerizer/mesos/paths.hpp
@@ -286,6 +286,44 @@ Option<ContainerID> parseCgroupPath(
     const std::string& cgroupsRoot,
     const std::string& cgroup);
 
+// All cgroups v2 paths are either leaf or non-leaf paths. Leaf paths end
+// in `/leaf`, contain processes, and may impose resource constraints. Non-leaf
+// paths do not contain processes and may impose resource constraints.
+// This is done to avoid the restrictions of the "Internal Process Contraint".
+// More information: https://docs.kernel.org/admin-guide/cgroup-v2.html#no-internal-process-constraint
+//
+// The cgroup2 file system has the structure:
+// <MOUNT>/<root>/agent                    Mesos Agent constraints
+// <MOUNT>/<root>/agent/leaf               Mesos Agent process
+//
+// <MOUNT>/<root>/<id>                     Container constraints
+// <MOUNT>/<root>/<id>/leaf                Container process
+//
+// <MOUNT>/<root>/<id>/mesos/<id2>         Nested container constraints
+// <MOUNT>/<root>/<id>/mesos/<id2>/leaf    Nested container process
+//
+// For every new level of nesting, `/mesos/<idN>` is added to the path.
+// Note: We assume these nested containers are not configured to "share"
+//       cgroups with their parent, in which case they would use the same cgroup
+//       paths as their parent.
+//
+// <root>        Value of the `cgroups_root` flag.
+// <MOUNT>       /sys/fs/cgroup, where the cgroup2 hierarchy is mounted.
+namespace cgroups2 {
+
+// Path to the Mesos Agent's cgroup.
+// `root` is the value of the `cgroups_root` flag.
+std::string agent(const std::string& root, bool leaf = false);
+
+
+// Path to a container's cgroup.
+// `root` is the value of the `cgroups_root` flag.
+std::string container(
+    const std::string& root,
+    const ContainerID& containerId,
+    bool leaf = false);
+
+} // namespace cgroups2 {
 } // namespace paths {
 } // namespace containerizer {
 } // namespace slave {

--- a/src/tests/containerizer/mesos_containerizer_paths_tests.cpp
+++ b/src/tests/containerizer/mesos_containerizer_paths_tests.cpp
@@ -95,6 +95,51 @@ TEST(MesosContainerizerPathsTest, BuildPathJoinMode)
       path::join(parent.value(), separator, child.value()));
 }
 
+TEST(MesosContainerizerPathsTest, CGROUPS2_Cgroups2Paths)
+{
+    namespace cgroups2 = mesos::internal::slave::containerizer::paths::cgroups2;
+
+    const string& ROOT = "mesos";
+
+    ContainerID parent;
+    parent.set_value("parent");
+
+    ContainerID child1;
+    child1.set_value("child2");
+    child1.mutable_parent()->CopyFrom(parent);
+
+    ContainerID child2;
+    child2.set_value("child2");
+    child2.mutable_parent()->CopyFrom(child1);
+
+    EXPECT_EQ("mesos/agent", cgroups2::agent(ROOT));
+    EXPECT_EQ("mesos/agent/leaf", cgroups2::agent(ROOT, true));
+
+    EXPECT_EQ(
+        path::join(ROOT, parent.value()), cgroups2::container(ROOT, parent));
+    EXPECT_EQ(path::join(
+        ROOT, parent.value(), "leaf"), cgroups2::container(ROOT, parent, true));
+
+    EXPECT_EQ(
+        path::join(ROOT, parent.value(), "mesos", child1.value()),
+        cgroups2::container(ROOT, child1));
+    EXPECT_EQ(
+        path::join(ROOT, parent.value(), "mesos", child1.value(), "leaf"),
+        cgroups2::container(ROOT, child1, true));
+
+    EXPECT_EQ(
+        path::join(
+            ROOT,
+            parent.value(), "mesos", child1.value(), "mesos", child2.value()),
+        cgroups2::container(ROOT, child2));
+    EXPECT_EQ(
+        path::join(
+            ROOT,
+            parent.value(),
+            "mesos", child1.value(), "mesos", child2.value(), "leaf"),
+        cgroups2::container(ROOT, child2, true));
+}
+
 } // namespace tests {
 } // namespace internal {
 } // namespace mesos {


### PR DESCRIPTION
Because of the unified hierarchy and internal processes constraint in cgroups v2, a new cgroup directory structure is used for cgroups in cgroups v2.

Here we introduce paths helpers and lay out the directory structure of the cgroup2 filesystem, used in cgroups v2.