### PR TITLE
[cgroups2] Removed templatized write() method.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -51,12 +51,6 @@ const string MOUNT_POINT = "/sys/fs/cgroup";
 template <typename T>
 Try<T> read(const string& cgroup, const string& control);
 
-template <typename T>
-Try<Nothing> write(
-    const string& cgroup,
-    const string& control,
-    const T& value);
-
 
 template <>
 Try<string> read(const string& cgroup, const string& control)
@@ -77,7 +71,6 @@ Try<uint64_t> read(const string& cgroup, const string& control)
 }
 
 
-template <>
 Try<Nothing> write(
     const string& cgroup,
     const string& control,
@@ -87,7 +80,6 @@ Try<Nothing> write(
 }
 
 
-template <>
 Try<Nothing> write(
     const string& cgroup,
     const string& control,


### PR DESCRIPTION
`cgroups2::write` does not need to be a template function (unlike `cgroups2::read`) because standard C++ overloading is sufficient to handle writing multiple different types, without definition conflicts.

Hence, we make `cgroups2::write` not a template function.