### PR TITLE
[cgroups2] 'cpu.max' parsing hotfix and introduces a test

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -499,7 +499,7 @@ Try<BandwidthLimit> parse_bandwidth(const string& content)
   //             is no limit.
   //
   // $PERIOD     Length of one period, in microseconds.
-  vector<string> split = strings::split(content, " ");
+  vector<string> split = strings::split(strings::trim(content), " ");
   if (split.size() != 2) {
     return Error("Expected format '$MAX $PERIOD'"
                  " but received '" + content + "'");


### PR DESCRIPTION
The 'cpu.max' file is terminated by a newline which causes an error
while parsing. Hence, we trim whitespace before we parse its contents.

A test is also introduced.