### PR TITLE
 [cgroups2] Introduces the CpuControllerProcess.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,7 +353,8 @@ if (ENABLE_CGROUPS_v2)
   list(APPEND LINUX_SRC
     linux/cgroups2.cpp
     linux/ebpf.cpp
-    slave/containerizer/mesos/isolators/cgroups2/controller.cpp)
+    slave/containerizer/mesos/isolators/cgroups2/controller.cpp
+    slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp)
 
 endif ()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1499,6 +1499,7 @@ MESOS_LINUX_FILES +=							\
   slave/containerizer/mesos/isolators/cgroups2/controller.hpp     \
   slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp     \
   slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp     \
+  slave/containerizer/mesos/isolators/cgroups2/constants.hpp     \
   slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp    \
   slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1498,7 +1498,9 @@ MESOS_LINUX_FILES +=							\
   slave/containerizer/mesos/isolators/cgroups2/controller.cpp     \
   slave/containerizer/mesos/isolators/cgroups2/controller.hpp     \
   slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp     \
-  slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
+  slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp     \
+  slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp    \
+  slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
 endif
 
 if ENABLE_SECCOMP_ISOLATOR

--- a/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
@@ -17,9 +17,23 @@
 #ifndef __CGROUPS_V2_ISOLATOR_CONSTANTS_HPP__
 #define __CGROUPS_V2_ISOLATOR_CONSTANTS_HPP__
 
+#include <string>
+
+#include <stout/duration.hpp>
+
 namespace mesos {
 namespace internal {
 namespace slave {
+
+// CPU controller constants.
+const uint64_t CPU_SHARES_PER_CPU = 1024;
+const uint64_t CPU_SHARES_PER_CPU_REVOCABLE = 10;
+const uint64_t MIN_CPU_SHARES = 2; // Linux constant.
+const Duration CPU_CFS_PERIOD = Milliseconds(100); // Linux default.
+const Duration MIN_CPU_CFS_QUOTA = Milliseconds(1);
+
+// Controller names.
+const std::string CGROUPS_V2_CONTROLLER_CPU_NAME = "cpu";
 
 } // namespace slave {
 } // namespace internal {

--- a/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __CGROUPS_V2_ISOLATOR_CONSTANTS_HPP__
+#define __CGROUPS_V2_ISOLATOR_CONSTANTS_HPP__
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {
+
+#endif // __CGROUPS_V2_ISOLATOR_CONSTANTS_HPP__

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controller.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controller.cpp
@@ -52,14 +52,6 @@ string Controller::name() const
 }
 
 
-Try<Owned<Controller>> Controller::create(
-    const Flags& flags,
-    const string& name)
-{
-  return Error("Controller '" + name + "' is not yet supported in cgroups v2");
-}
-
-
 Future<Nothing> Controller::recover(
     const ContainerID& containerId,
     const string& cgroup)

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controller.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controller.hpp
@@ -37,9 +37,7 @@ class ControllerProcess;
 class Controller
 {
 public:
-  static Try<process::Owned<Controller>> create(
-      const Flags& flags,
-      const std::string& name);
+  explicit Controller(process::Owned<ControllerProcess> process);
 
   // Copied from: src/slave/containerizer/mesos/isolators/cgroups/subsystem.hpp
   // We have unique ownership of the wrapped process and
@@ -92,8 +90,6 @@ public:
       const std::string& cgroup);
 
 private:
-  explicit Controller(process::Owned<ControllerProcess> process);
-
   process::Owned<ControllerProcess> process;
 };
 

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp
@@ -14,4 +14,158 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
+#include "linux/cgroups2.hpp"
+
+#include "slave/containerizer/mesos/isolators/cgroups2/constants.hpp"
 #include "slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp"
+
+#include <process/id.hpp>
+#include <process/owned.hpp>
+
+#include <stout/duration.hpp>
+#include <stout/foreach.hpp>
+#include <stout/nothing.hpp>
+#include <stout/option.hpp>
+#include <stout/try.hpp>
+
+#include "logging/logging.hpp"
+
+using std::string;
+
+using process::Failure;
+using process::Future;
+using process::Owned;
+
+using cgroups2::cpu::BandwidthLimit;
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+Try<Owned<ControllerProcess>> CpuControllerProcess::create(const Flags& flags)
+{
+  return Owned<ControllerProcess>(new CpuControllerProcess(flags));
+}
+
+
+CpuControllerProcess::CpuControllerProcess(const Flags& _flags)
+  : ProcessBase(process::ID::generate("cgroups-v2-cpu-controller")),
+    ControllerProcess(_flags) {}
+
+
+string CpuControllerProcess::name() const
+{
+  return CGROUPS_V2_CONTROLLER_CPU_NAME;
+}
+
+
+Future<Nothing> CpuControllerProcess::update(
+  const ContainerID& containerId,
+  const string& cgroup,
+  const Resources& resourceRequests,
+  const google::protobuf::Map<string, Value::Scalar>& resourceLimits)
+{
+  if (resourceRequests.cpus().isNone()) {
+    return Failure(
+        "Failed to update the 'cpu' controller: No cpu resources requested");
+  }
+
+  // Compute and update the CPU weight for this cgroup. Weight is the product of
+  // the requested number of CPUs and the pre-set weight per CPU. If the
+  // `revocable_cpu_low_priority` flag is set, less weight is given per cpu.
+  double cpus = *resourceRequests.cpus();
+  bool revocable = resourceRequests.revocable().cpus().isSome();
+  uint64_t weightPerCpu = revocable && flags.revocable_cpu_low_priority ?
+      CPU_SHARES_PER_CPU_REVOCABLE : CPU_SHARES_PER_CPU;
+  uint64_t weight = std::max(
+      static_cast<uint64_t>(weightPerCpu * cpus), MIN_CPU_SHARES);
+
+  Try<Nothing> update = cgroups2::cpu::weight(cgroup, weight);
+  if (update.isError()) {
+    return Failure("Failed to update the weight: " + update.error());
+  }
+
+  Option<double> cpuLimit;
+  if (resourceLimits.count("cpus")) {
+    cpuLimit = resourceLimits.at("cpus").value();
+  }
+
+  // Set a maximum bandwidth per `CPU_CFS_PERIOD`, if a limit is requested.
+  //
+  // If `cpuLimit` is provided, the bandwidth is the product of the limit
+  // and the `CPU_CFS_PERIOD`. Otherwise, if the flag `cgroups_enable_cfs`
+  // is provided, it is the product of `cpus` and the `CPU_CFS_PERIOD`.
+  Option<BandwidthLimit> limit = [=, &cpuLimit] () -> Option<BandwidthLimit> {
+    uint64_t min_quota = static_cast<uint64_t>(MIN_CPU_CFS_QUOTA.us());
+    if (cpuLimit.isSome()) {
+      if (std::isinf(*cpuLimit)) {
+        return BandwidthLimit();
+      }
+
+      uint64_t quota = static_cast<uint64_t>(*cpuLimit * CPU_CFS_PERIOD.us());
+      return BandwidthLimit(
+          CPU_CFS_PERIOD,
+          Microseconds(std::max(quota, min_quota)));
+    }
+
+    if (flags.cgroups_enable_cfs) {
+      uint64_t quota = static_cast<uint64_t>(cpus * CPU_CFS_PERIOD.us());
+      return BandwidthLimit(
+          CPU_CFS_PERIOD,
+          Microseconds(std::max(quota, min_quota)));
+    }
+
+    return None();
+  }();
+
+  if (limit.isSome()) {
+    Try<Nothing> update = cgroups2::cpu::set_max(cgroup, *limit);
+    if (update.isError()) {
+      return Failure(
+          "Failed to update bandwidth limit for cgroup '" + cgroup + "': "
+          + update.error());
+    }
+  }
+
+  return Nothing();
+}
+
+
+Future<ResourceStatistics> CpuControllerProcess::usage(
+    const ContainerID& _containerId,
+    const string& cgroup)
+{
+  ResourceStatistics usage;
+  Try<cgroups2::cpu::Stats> stats = cgroups2::cpu::stats(cgroup);
+  if (stats.isError()) {
+    return Failure("Failed to get CPU stats: " + stats.error());
+  }
+
+  if (stats->periods.isSome()) {
+   usage.set_cpus_nr_periods(*stats->periods);
+  }
+  if (stats->throttled.isSome()) {
+    usage.set_cpus_nr_throttled(*stats->throttled);
+  }
+  if (stats->throttle_time.isSome()) {
+    usage.set_cpus_throttled_time_secs(stats->throttle_time->secs());
+  }
+
+  if (stats->periods.isNone()
+      || stats->throttled.isNone()
+      || stats->throttle_time.isNone()) {
+    LOG(ERROR) << "cpu usage and throttling stats not found"
+                  " despite the 'cpu' controller being enabled";
+  }
+
+  usage.set_cpus_user_time_secs(stats->user_time.secs());
+  usage.set_cpus_system_time_secs(stats->system_time.secs());
+
+  return usage;
+}
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp
@@ -1,0 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp"

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __CPU_HPP__
+#define __CPU_HPP__
+
+#endif // __CPU_HPP__

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
@@ -17,4 +17,45 @@
 #ifndef __CPU_HPP__
 #define __CPU_HPP__
 
+#include <string>
+
+#include <process/future.hpp>
+
+#include "slave/containerizer/mesos/isolators/cgroups2/controller.hpp"
+
+#include "slave/flags.hpp"
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+class CpuControllerProcess : public ControllerProcess
+{
+public:
+  static Try<process::Owned<ControllerProcess>> create(
+      const Flags& flags);
+
+  ~CpuControllerProcess() override = default;
+
+  std::string name() const override;
+
+  process::Future<Nothing> update(
+    const ContainerID& containerId,
+    const std::string& cgroup,
+    const Resources& resourceRequests,
+    const google::protobuf::Map<
+        std::string, Value::Scalar>& resourceLimits = {}) override;
+
+  process::Future<ResourceStatistics> usage(
+      const ContainerID& containerId,
+      const std::string& cgroup) override;
+
+private:
+  CpuControllerProcess(const Flags& flags);
+};
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {
+
 #endif // __CPU_HPP__


### PR DESCRIPTION
Introduces the `CpuControllerProcess`, a cpu isolator that is
implemented using cgroups v2 and indirectly exposed through the
`Cgroups2IsolatorProcess`. Hosts correctly configured for cgroups v2
that provide `cgroups/cpu` in the `isolation` flag and `cpu`
in the `agent_subsystems` flag will use this controller.