### PR TITLE
[cgroups2] Introduce interface for reading threads in a cgroup.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -84,6 +84,10 @@ Try<std::string> cgroup(pid_t pid);
 Try<std::set<pid_t>> processes(const std::string& cgroup);
 
 
+// Get the threads inside of a cgroup.
+Try<std::set<pid_t>> threads(const std::string& cgroup);
+
+
 // Get the absolute of a cgroup. The cgroup provided should not start with '/'.
 std::string path(const std::string& cgroup);
 

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -14,8 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <set>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -38,7 +40,9 @@
 using std::pair;
 using std::set;
 using std::string;
+using std::thread;
 using std::tuple;
+using std::unique_ptr;
 using std::vector;
 
 namespace cpu = cgroups2::cpu;
@@ -178,6 +182,67 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_AssignProcesses)
   // Kill the child process.
   ASSERT_NE(-1, ::kill(pid, SIGKILL));
   AWAIT_EXPECT_WTERMSIG_EQ(SIGKILL, process::reap(pid));
+}
+
+
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_Threads)
+{
+  const size_t NUM_THREADS = 5;
+
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+
+  pid_t pid = ::fork();
+  ASSERT_NE(-1, pid);
+
+  if (pid == 0) {
+    vector<unique_ptr<std::thread>> runningThreads(NUM_THREADS);
+
+    for (size_t i = 0; i < NUM_THREADS; ++i) {
+      runningThreads[i] = unique_ptr<std::thread>(new std::thread([]() {
+        while (true);
+      }));
+    }
+
+    // Check the test cgroup is initially empty.
+    Try<set<pid_t>> cgroupThreads = cgroups2::threads(TEST_CGROUP);
+    if (cgroupThreads.isError()) {
+      SAFE_EXIT(
+          EXIT_FAILURE,
+          "Failed to read threads in cgroup '%s'",
+          TEST_CGROUP.c_str());
+    }
+    if (!cgroupThreads->empty()) {
+      SAFE_EXIT(
+          EXIT_FAILURE, "Expected cgroup to have no threads, after creation");
+    }
+
+    // Assign ourselves to the test cgroup.
+    if (cgroups2::assign(TEST_CGROUP, ::getpid()).isError()) {
+      SAFE_EXIT(EXIT_FAILURE, "Failed to assign 'this' to the test cgroup");
+    }
+
+    Try<set<pid_t>> threads = proc::threads(::getpid());
+    if (threads.isError()) {
+      SAFE_EXIT(EXIT_FAILURE, "Failed to read threads in 'this' process");
+    }
+
+    // Check that the test cgroup now only contains all child threads.
+    cgroupThreads = cgroups2::threads(TEST_CGROUP);
+    if (cgroupThreads.isError()) {
+      SAFE_EXIT(
+          EXIT_FAILURE,
+          "Failed to read threads in cgroup '%s'",
+          TEST_CGROUP.c_str());
+    }
+    if (*threads != *cgroupThreads) {
+      SAFE_EXIT(EXIT_FAILURE, "The threads in the cgroup did not match the "
+                              "processes's threads");
+    }
+
+    ::_exit(EXIT_SUCCESS);
+  }
+
+  AWAIT_EXPECT_WEXITSTATUS_EQ(EXIT_SUCCESS, process::reap(pid));
 }
 
 


### PR DESCRIPTION
- `cgroups2::threads` reads the threads in a cgroup into a `set`, similar to `cgroups2::processes`.

Moving a process into a cgroup moves all the threads in that process into the cgroup. A test is introduced to ensure the threads move, as expected.