### PR TITLE
[cgroups2] Adds the `CoreControllerProcess` to the `Cgroups2IsolatorProcess`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,6 +354,7 @@ if (ENABLE_CGROUPS_v2)
     linux/cgroups2.cpp
     linux/ebpf.cpp
     slave/containerizer/mesos/isolators/cgroups2/controller.cpp
+    slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
     slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp)
 
 endif ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1500,6 +1500,8 @@ MESOS_LINUX_FILES +=							\
   slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp     \
   slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp     \
   slave/containerizer/mesos/isolators/cgroups2/constants.hpp     \
+  slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp     \
+  slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp     \
   slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp    \
   slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.hpp
 endif

--- a/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/constants.hpp
@@ -32,7 +32,8 @@ const uint64_t MIN_CPU_SHARES = 2; // Linux constant.
 const Duration CPU_CFS_PERIOD = Milliseconds(100); // Linux default.
 const Duration MIN_CPU_CFS_QUOTA = Milliseconds(1);
 
-// Controller names.
+const std::string CGROUPS_V2_CONTROLLER_CORE_NAME =
+  "core"; // Interfaces with "cgroup.*" control files
 const std::string CGROUPS_V2_CONTROLLER_CPU_NAME = "cpu";
 
 } // namespace slave {

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
@@ -14,4 +14,70 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <set>
+#include <string>
+
+#include "linux/cgroups2.hpp"
+
+#include "slave/containerizer/mesos/isolators/cgroups2/constants.hpp"
 #include "slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp"
+
+#include <process/id.hpp>
+#include <process/owned.hpp>
+
+using process::Failure;
+using process::Future;
+using process::Owned;
+
+using std::set;
+using std::string;
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+Try<Owned<ControllerProcess>> CoreControllerProcess::create(const Flags& flags)
+{
+  return Owned<ControllerProcess>(new CoreControllerProcess(flags));
+}
+
+
+CoreControllerProcess::CoreControllerProcess(const Flags& _flags)
+  : ProcessBase(process::ID::generate("cgroups-v2-core-controller")),
+    ControllerProcess(_flags) {}
+
+
+string CoreControllerProcess::name() const
+{
+  return CGROUPS_V2_CONTROLLER_CORE_NAME;
+}
+
+
+process::Future<ResourceStatistics> CoreControllerProcess::usage(
+    const ContainerID& containerId,
+    const std::string& cgroup)
+{
+  ResourceStatistics stats;
+
+  if (flags.cgroups_cpu_enable_pids_and_tids_count) {
+    Try<set<pid_t>> pids = cgroups2::processes(cgroup);
+    if (pids.isError()) {
+      return Failure("Failed to get processes in cgroup: " + pids.error());
+    }
+
+    stats.set_processes(pids->size());
+
+    Try<set<pid_t>> tids = cgroups2::threads(cgroup);
+    if (tids.isError()) {
+      return Failure("Failed to get threads in cgroup: " + tids.error());
+    }
+
+    stats.set_threads(tids->size());
+  }
+
+  return stats;
+}
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
@@ -1,0 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp"

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __CORE_HPP__
+#define __CORE_HPP__
+
+namespace mesos {
+namespace internal {
+namespace slave {
+
+
+
+} // namespace slave {
+} // namespace internal {
+} // namespace mesos {
+
+#endif ___CORE_HPP__

--- a/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/controllers/core.hpp
@@ -17,14 +17,39 @@
 #ifndef __CORE_HPP__
 #define __CORE_HPP__
 
+#include <string>
+
+#include <process/future.hpp>
+
+#include "slave/containerizer/mesos/isolators/cgroups2/controller.hpp"
+#include "slave/flags.hpp"
+
 namespace mesos {
 namespace internal {
 namespace slave {
 
+// Controller to interface with the cgroups core control files. That is,
+// control files "cgroup.*", which exist in all cgroups.
+class CoreControllerProcess : public ControllerProcess
+{
+public:
+  static Try<process::Owned<ControllerProcess>> create(
+      const Flags& flags);
 
+  ~CoreControllerProcess() override = default;
+
+  std::string name() const override;
+
+  process::Future<ResourceStatistics> usage(
+      const ContainerID& containerId,
+      const std::string& cgroup) override;
+
+private:
+  CoreControllerProcess(const Flags& flags);
+};
 
 } // namespace slave {
 } // namespace internal {
 } // namespace mesos {
 
-#endif ___CORE_HPP__
+#endif // __CORE_HPP__


### PR DESCRIPTION
The `CoreControllerProcess`, referred to as the "core" controller, is
implemented and enabled by default by the cgroups v2 isolator process.

We enable it by default because all cgroups in cgroups v2 have the
core control files ("cgroup.*"), which the `CoreControllerProcess` manages.

Currently, `CoreControllerProcess` reports the number of processes and
threads in a cgroup, if the `cgroups_cpu_enable_pids_and_tids_count`
flag is provided.