### PR TITLE
Removed dead field 'subsystem' from the `LinuxLauncherProcess`.

### DIFF
--- a/src/slave/containerizer/mesos/linux_launcher.cpp
+++ b/src/slave/containerizer/mesos/linux_launcher.cpp
@@ -104,7 +104,6 @@ private:
 
   Future<Nothing> _destroy(const ContainerID& containerId);
 
-  static const string subsystem;
   const Flags flags;
   const string freezerHierarchy;
   const Option<string> systemdHierarchy;


### PR DESCRIPTION
Removed an unused static field `subsystem` from the `LinuxLauncherProcess`.