### PR TITLE
[cgroups2] Introduced API to kill the processes inside of cgroup subtree.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -69,8 +69,13 @@ Try<std::set<std::string>> get(const std::string& cgroup = ROOT_CGROUP);
 Try<Nothing> create(const std::string& cgroup, bool recursive = false);
 
 
-// Destroy a cgroup. If the cgroup does not exist or cannot be destroyed,
-// e.g. because it contains processes, an error is returned.
+// Recursively kill all of the processes inside of a cgroup and all child
+// cgroups with SIGKILL.
+Try<Nothing> kill(const std::string& cgroup);
+
+
+// Recursively destroy a cgroup and all nested cgroups. Processes inside of
+// destroyed cgroups are killed with SIGKILL.
 Try<Nothing> destroy(const std::string& cgroup);
 
 

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -360,12 +360,6 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_GetCgroups)
         path::join(TEST_CGROUP, "test1/b/c")
       }),
       cgroups2::get(path::join(TEST_CGROUP, "test1/b")));
-
-  // Destroy the cgroups in reverse order so the most deeply-nested cgroups
-  // are removed first.
-  for (int i = cgroups.size() - 1; i >= 0; --i) {
-    ASSERT_SOME(cgroups2::destroy(cgroups[i]));
-  }
 }
 
 


### PR DESCRIPTION
Introduces
```
	cgroups2::kill(cgroup)
```
which will recursively kill all of the cgroups in a subtree.

We additionally update `cgroups::destroy` to use `cgroups::kill` such that it now completely destroys a cgroup (i.e. all directories processes).