### PR TITLE
[cgroups2] Introduce `memory` controller.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -767,6 +767,27 @@ Try<cpu::BandwidthLimit> max(const string& cgroup)
 
 } // namespace cpu {
 
+namespace memory {
+
+namespace control {
+
+const string CURRENT = "memory.current";
+
+} // namespace control {
+
+Try<Bytes> usage(const string& cgroup)
+{
+  Try<string> contents = cgroups2::read<string>(
+      cgroup, memory::control::CURRENT);
+  if (contents.isError()) {
+    return Error("Failed to read 'memory.current': " + contents.error());
+  }
+
+  return Bytes::parse(strings::trim(*contents) + "B");
+}
+
+} // namespace memory {
+
 namespace devices {
 
 // Utility class to construct an eBPF program to whitelist or blacklist

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <stout/bytes.hpp>
 #include <stout/duration.hpp>
 #include <stout/nothing.hpp>
 #include <stout/option.hpp>
@@ -213,6 +214,13 @@ Try<Nothing> set_max(const std::string& cgroup, const BandwidthLimit& limit);
 Try<BandwidthLimit> max(const std::string& cgroup);
 
 } // namespace cpu {
+
+namespace memory {
+
+// Current memory usage of a cgroup and its descendants in bytes.
+Try<Bytes> usage(const std::string& cgroup);
+
+} // namespace memory {
 
 namespace devices {
 

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -311,6 +311,20 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_CpuBandwidthLimit)
 }
 
 
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryUsage)
+{
+  ASSERT_SOME(enable_controllers({"memory"}));
+
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+  ASSERT_SOME(cgroups2::controllers::enable(TEST_CGROUP, {"memory"}));
+
+  // Does not exist for the root cgroup.
+  EXPECT_ERROR(cgroups2::memory::usage(cgroups2::ROOT_CGROUP));
+
+  EXPECT_SOME(cgroups2::memory::usage(TEST_CGROUP));
+}
+
+
 TEST_F(Cgroups2Test, ROOT_CGROUPS2_GetCgroups)
 {
   vector<string> cgroups = {


### PR DESCRIPTION
Introduces the cgroups v2 `memory` controller, the `cgroups2::memory::usage` function, to obtain the memory usage of a cgroup and its descendants' , and a test.