### PR TITLE
[cgroups2] Cgroups v2 isolator initialization and mount setup.

### DIFF
--- a/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
@@ -18,9 +18,12 @@
 #define __CGROUPS_V2_ISOLATOR_HPP__
 
 #include <string>
+#include <vector>
 
+#include <process/future.hpp>
 #include <process/owned.hpp>
 
+#include <stout/nothing.hpp>
 #include <stout/hashmap.hpp>
 #include <stout/try.hpp>
 
@@ -43,12 +46,100 @@ public:
 
   bool supportsStandalone() override;
 
+  process::Future<Option<mesos::slave::ContainerLaunchInfo>> prepare(
+      const ContainerID& containerId,
+      const mesos::slave::ContainerConfig& containerConfig) override;
+
+  process::Future<Nothing> recover(
+      const std::vector<mesos::slave::ContainerState>& states,
+      const hashset<ContainerID>& orphans) override;
+
+  process::Future<Nothing> isolate(
+      const ContainerID& containerId,
+      pid_t pid) override;
+
+  process::Future<Nothing> update(
+      const ContainerID& containerId,
+      const Resources& resourceRequests,
+      const google::protobuf::Map<
+          std::string, Value::Scalar>& resourceLimits = {}) override;
+
+  process::Future<ContainerStatus> status(
+      const ContainerID& containerId) override;
+
+  process::Future<Nothing> cleanup(const ContainerID& containerId) override;
 private:
+  struct Info
+  {
+    Info(const ContainerID& _containerId, const std::string& _cgroup)
+      : containerId(_containerId), cgroup(_cgroup) {}
+
+    const ContainerID containerId;
+
+    // Domain cgroup for the container. Control files in this cgroup are
+    // updated to set resource constraints on this and descendant
+    // containers. Processes should not be assigned to this cgroup.
+    const std::string cgroup;
+
+    // Names of the controllers which are prepared for the container.
+    hashset<std::string> controllers;
+  };
+
   Cgroups2IsolatorProcess(
+      const Flags& flags,
       const hashmap<std::string, process::Owned<Controller>>& controllers);
 
+  process::Future<Option<mesos::slave::ContainerLaunchInfo>> _prepare(
+    const ContainerID& containerId,
+    const mesos::slave::ContainerConfig& containerConfig,
+    const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Option<mesos::slave::ContainerLaunchInfo>> __prepare(
+      const ContainerID& containerId,
+      const mesos::slave::ContainerConfig& containerConfig);
+
+  process::Future<Nothing> _recover(
+    const hashset<ContainerID>& orphans,
+    const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Nothing> __recover(
+      const hashset<ContainerID>& unknownOrphans,
+      const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Nothing> ___recover(
+      const ContainerID& containerId);
+
+  process::Future<Nothing> ____recover(
+      const ContainerID& containerId,
+      const hashset<std::string>& recoveredSubsystems,
+      const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Nothing> _isolate(
+      const std::vector<process::Future<Nothing>>& futures,
+      const ContainerID& containerId,
+      pid_t pid);
+
+  process::Future<Nothing> _update(
+      const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Nothing> _cleanup(
+      const ContainerID& containerId,
+      const std::vector<process::Future<Nothing>>& futures);
+
+  process::Future<Nothing> __cleanup(
+      const ContainerID& containerId,
+      const std::vector<process::Future<Nothing>>& futures);
+
+  process::Owned<Cgroups2IsolatorProcess::Info> cgroupInfo(
+      const ContainerID& containerId) const;
+
+  Flags flags;
+
   // Maps each controller to the `Controller` isolator that manages it.
-  const hashmap<std::string, process::Owned<Controller>> controllers;
+  hashmap<std::string, process::Owned<Controller>> controllers;
+
+  // Associates a container with the information to access its controllers.
+  hashmap<ContainerID, process::Owned<Info>> infos;
 };
 
 } // namespace slave {


### PR DESCRIPTION
Updates the cgroups v2 isolator to include initialization, cleanup, update, and recovery logic.

Unlike cgroups v1 we:
- Create a new cgroup namespace during isolation, by introducing a new clone namespace flag. This implies that the contained process will only have access to cgroups in its cgroup subtree
- We only need to recover two cgroups (the domain and leaf cgroups [1]) for each container, rather than having to recover one cgroup for each controller the container used.
- We do not (yet) support nested containers.

Using the cgroups v2 isolator requires Mesos to be compiled with `--enable-cgroups-v2` and to have the cgroup2 filesystem mounted at /sys/fs/cgroup. Selecting the correct isolator version (v1 or v2) is done automatically. V2 is used if the host supports cgroups v2 and is correctly configured.

[1] The "domain" cgroup is the cgroup for a container where resource
    constraints are imposed. The "leaf" cgroup, which has the path
    <domain cgroup>/leaf, is where the container PID is put.
    Container PIDs are only put in leaf cgroups.