### PR TITLE
 [cgroups2] Introduced an interface to set a hard memory limit.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -261,6 +261,19 @@ Try<Nothing> set_min(const std::string& cgroup, const Bytes& bytes);
 // Cannot be used for the root cgroup.
 Try<Bytes> min(const std::string& cgroup);
 
+
+// Set the maximum memory that can be used by a cgroup and its descendants.
+// Exceeding the limit will trigger the OOM killer.
+// If limit is None, then there is no maximum memory limit.
+// Cannot be used for the root cgroup.
+Try<Nothing> set_max(const std::string& cgroup, const Option<Bytes>& limit);
+
+
+// Get the maximum memory that can be used by a cgroup and its descendants.
+// If the returned limit is None, then there is no maximum memory limit.
+// Cannot be used for the root cgroup.
+Result<Bytes> max(const std::string& cgroup);
+
 } // namespace memory {
 
 namespace devices {

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -372,6 +372,27 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryBytesRounding)
 }
 
 
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryMaximum)
+{
+  ASSERT_SOME(enable_controllers({"memory"}));
+
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+  ASSERT_SOME(cgroups2::controllers::enable(TEST_CGROUP, {"memory"}));
+
+  Bytes limit = Bytes(os::pagesize()) * 5;
+
+  // Does not exist for the root cgroup.
+  EXPECT_ERROR(cgroups2::memory::max(cgroups2::ROOT_CGROUP));
+  EXPECT_ERROR(cgroups2::memory::set_max(cgroups2::ROOT_CGROUP, limit));
+
+  EXPECT_SOME(cgroups2::memory::set_max(TEST_CGROUP, limit));
+  EXPECT_SOME_EQ(limit, cgroups2::memory::max(TEST_CGROUP));
+
+  EXPECT_SOME(cgroups2::memory::set_max(TEST_CGROUP, None()));
+  EXPECT_NONE(cgroups2::memory::max(TEST_CGROUP));
+}
+
+
 TEST_F(Cgroups2Test, ROOT_CGROUPS2_GetCgroups)
 {
   vector<string> cgroups = {


### PR DESCRIPTION
The "memory.max" control contains the hard memory limit that a cgroup
and its descendants must remain below.

We introduce `cgroups2::memory::set_max` and `cgroups2::memory::max`
to set and get this limit.
