### PR TITLE
[cgroups2] Introduces API to make cgroups threaded and check their type.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -101,6 +101,41 @@ Try<std::set<pid_t>> threads(const std::string& cgroup);
 // Get the absolute of a cgroup. The cgroup provided should not start with '/'.
 std::string path(const std::string& cgroup);
 
+// Cgroup types.
+// "domain": Allows the cgroup to manage resources.
+//
+// "threaded": Allows threads to live in internal nodes but can only enable
+//             the "cpu", "cpuset", "perf_event", and "pids" controllers.
+namespace type {
+
+// Domain cgroup.
+const std::string DOMAIN = "domain";
+
+// Threaded cgroup.
+const std::string THREADED = "threaded";
+
+// Domain cgroup that serves as the root of a threaded subtree.
+const std::string THREADED_DOMAIN = "domain threaded";
+
+// Cgroup in an invalid state. Can't be assigned processes or have controllers
+// enabled.
+const std::string INVALID = "domain invalid";
+
+// Convert a cgroup into a threaded cgroup. Once a cgroup is made threaded
+// it cannot be made into a domain cgroup again.
+//
+// Cannot be used for the root cgroup.
+Try<Nothing> set_threaded(const std::string& cgroup);
+
+
+// Get the type of a cgroup.
+// Note: See the top-level `cgroups2::type` comment about types.
+//
+// Cannot be used for the root cgroup.
+Try<std::string> get(const std::string& cgroup);
+
+} // namespace type {
+
 namespace controllers {
 
 // Gets the controllers that can be controlled by the provided cgroup.

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -463,6 +463,25 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_GetCgroups)
 }
 
 
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_CgroupTypes)
+{
+  ASSERT_SOME(enable_controllers({"memory"}));
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+
+  // Does not exist for the root cgroup.
+  EXPECT_ERROR(cgroups2::type::get(cgroups2::ROOT_CGROUP));
+
+  // Check that the test cgroup is a domain cgroup by default.
+  EXPECT_SOME_EQ(cgroups2::type::DOMAIN, cgroups2::type::get(TEST_CGROUP));
+
+  // Make the test cgroup threaded and check that it can't enable the memory
+  // controller.
+  EXPECT_SOME(cgroups2::type::set_threaded(TEST_CGROUP));
+  EXPECT_SOME_EQ(cgroups2::type::THREADED, cgroups2::type::get(TEST_CGROUP));
+  EXPECT_ERROR(cgroups2::controllers::enable(TEST_CGROUP, {"memory"}));
+}
+
+
 // Arguments for os::open(). Combination of a path and an access type.
 typedef pair<string, int> OpenArgs;
 


### PR DESCRIPTION
The control 'cgroup.type' contains the type of a cgroup. Cgroups are either 'threaded' or 'domain'. Threaded cgroups can contain threads in internal cgroups but can only enable the "cpu", "cpuset", "perf_event", and "pids" controllers. Domain cgroups cannot contain internal processes but can enable any controller.

In cgroups v2, container pids are to be placed exclusively in "leaf" cgroups in the cgroup hierarchy. Controllers should not be enabled in "leaf" cgroups and they should not have any child cgroups. To help enforce these constraints, we will make "leaf cgroups" threaded, hence this commit which extends our library to allow us to make a cgroup threaded.