### PR TITLE
  [cgroups2] Introduced API to listen for OOM events.

### DIFF
--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include <process/future.hpp>
 #include <process/reap.hpp>
 #include <process/gmock.hpp>
 #include <process/gtest.hpp>
@@ -37,6 +38,10 @@
 
 #include "linux/cgroups2.hpp"
 #include "linux/ebpf.hpp"
+
+#include "tests/containerizer/memory_test_helper.hpp"
+
+using process::Future;
 
 using std::pair;
 using std::set;
@@ -481,6 +486,46 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_GetCgroups)
         path::join(TEST_CGROUP, "test1/b/c")
       }),
       cgroups2::get(path::join(TEST_CGROUP, "test1/b")));
+}
+
+
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_OomDetection)
+{
+  // Check that exceeding the hard memory limit will trigger an OOM event.
+  //
+  // We set a hard memory limit on the test cgroup, move a process inside of
+  // the test cgroup subtree, listen for an OOM event, deliberately trigger an
+  // OOM event by exceeding the hard limit, and then check that an event was
+  // triggered.
+  ASSERT_SOME(enable_controllers({"memory"}));
+
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+  ASSERT_SOME(cgroups2::controllers::enable(TEST_CGROUP, {"memory"}));
+
+  const string leaf_cgroup = TEST_CGROUP + "/leaf";
+  ASSERT_SOME(cgroups2::create(leaf_cgroup));
+
+  Try<os::Memory> memory = os::memory();
+  ASSERT_SOME(memory);
+
+  MemoryTestHelper helper;
+  ASSERT_SOME(helper.spawn());
+  ASSERT_SOME(helper.pid());
+
+  Bytes limit = Megabytes(32);
+
+  ASSERT_SOME(cgroups2::assign(leaf_cgroup, *helper.pid()));
+  ASSERT_SOME(cgroups2::memory::set_max(TEST_CGROUP, limit));
+
+  Future<Nothing> oomEvent = cgroups2::memory::event::oom(TEST_CGROUP);
+
+  // Assert that the OOM event has not been triggered.
+  EXPECT_FALSE(oomEvent.isReady());
+
+  // Increase memory usage beyond the limit.
+  ASSERT_ERROR(helper.increaseRSS(limit * 2));
+
+  AWAIT_EXPECT_READY(oomEvent);
 }
 
 


### PR DESCRIPTION
Introduces `cgroups2::memory::events::oom` which returns a future that resolves when the cgroup reaches its memory limit and is about to fail with an OOM.

In cgroups v1, there was a bespoke notification API. The same does not exist in cgroups v2, meaning a new mechanism is used to detect OOM events.

Cgroups v2 provides the control 'memory.events' which contains key-value pairs of events and the number of times they took place [1]. For OOMs, we look at the value of the `oom` field. In `cgroups2::memory::events::oom` we poll, every 100ms, for changes to 'memory.events' and resolve a future when `events.oom > 0`, indicating that _"the cgroup’s memory usage was reached the limit and allocation [is] about to fail."_

This will be used inside of the `MemoryControllerProcess`, an isolator what will be provided by the `Cgroups2IsolatorProcess`.

[1] https://docs.kernel.org/admin-guide/cgroup-v2.html#memory