### PR TITLE
[cgroups2] Introduces an interface to read a subset of the memory usage statistics.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -243,6 +243,41 @@ Try<BandwidthLimit> max(const std::string& cgroup);
 // See: https://docs.kernel.org/admin-guide/cgroup-v2.html
 namespace memory {
 
+// Memory usage statistics.
+//
+// Snapshot of the 'memory.stat' control file.
+//
+// Note:
+// We only record a subset of the memory statistics; a complete list can be
+// found in the kernel documentation.
+// https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files
+struct Stats
+{
+  // Anonymous memory usage.
+  Bytes anon;
+
+  // Cached filesystem data, including tmpfs and shared memory.
+  Bytes filesystem_cache;
+
+  // Kernel memory usage.
+  Bytes kernel;
+
+  // Kernel stack memory usage.
+  Bytes kernel_stack;
+
+  // Page table memory usage.
+  Bytes pagetables;
+
+  // TCP network transmission buffers usage.
+  Bytes socket;
+
+  // VMAP backed memory usage.
+  Bytes vmap_backed;
+
+  // Cached filesystem data mapped with `mmap()`.
+  Bytes mapped_filesystem_cache;
+};
+
 // Cgroup memory controller events.
 //
 // Snapshot of the 'memory.events' or 'memory.local.events' control files.
@@ -357,6 +392,12 @@ Try<Nothing> set_high(
 //
 // Cannot be used for the root cgroup.
 Result<Bytes> high(const std::string& cgroup);
+
+
+// Get the memory usage statistics for a cgroup.
+//
+// Cannot be used for the root cgroup.
+Try<Stats> stats(const std::string& cgroup);
 
 } // namespace memory {
 

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -331,6 +331,16 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryUsage)
 }
 
 
+TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryStats)
+{
+  ASSERT_SOME(enable_controllers({"memory"}));
+
+  ASSERT_SOME(cgroups2::create(TEST_CGROUP));
+  ASSERT_SOME(cgroups2::controllers::enable(TEST_CGROUP, {"memory"}));
+  ASSERT_SOME(cgroups2::memory::stats(TEST_CGROUP));
+}
+
+
 TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryLow)
 {
   ASSERT_SOME(enable_controllers({"memory"}));


### PR DESCRIPTION
Cgroups v2 exposes memory statistics through the 'memory.stat' control.

Here we introduce `cgroups2::memory::stats` to read a subset of the memory usage statistics into a new `memory::Stats` object. These statistics will be used by the `MemoryControllerProcess` to populate a `ResourceStatistics` object, like is done by the `MemorySubsystemProcess` in cgroups v1.

Additional statistics from the 'memory.stat' control can be included as they are required.