### PR TITLE
[cgroups2] Error if `--cgroups_limit_swap` is used when cgroups v2 is used.

### DIFF
--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -330,7 +330,8 @@ The path to the cgroups hierarchy root. (default: /sys/fs/cgroup)
   </td>
   <td>
 Cgroups feature flag to enable memory limits on both memory and
-swap instead of just memory. (default: false)
+swap instead of just memory. Not supported if cgroups v2 is used.
+(default: false)
   </td>
 </tr>
 


### PR DESCRIPTION
Mesos does not support limiting swap memory when using cgroups v2. This is because the cgroups v2 API does not allow us to directly control the swap memory usage limit.  Rather, we can only control the combined swap _and_ RAM usage limit.

Therefore, when the `--cgroups_limit_swap` flag is provided and cgroups v2 is used we error during flag validation.