### PR TITLE
[cgroups2] Introduces API to read the peak memory usage.

### DIFF
--- a/src/linux/cgroups2.cpp
+++ b/src/linux/cgroups2.cpp
@@ -811,6 +811,7 @@ const string LOW = "memory.low";
 const string HIGH = "memory.high";
 const string MAX = "memory.max";
 const string MIN = "memory.min";
+const string PEAK = "memory.peak";
 const string STAT = "memory.stat";
 
 namespace stat {
@@ -926,6 +927,18 @@ Try<Bytes> usage(const string& cgroup)
       cgroup, memory::control::CURRENT);
   if (contents.isError()) {
     return Error("Failed to read 'memory.current': " + contents.error());
+  }
+
+  return Bytes(*contents);
+}
+
+
+Try<Bytes> peak_usage(const std::string& cgroup)
+{
+  Try<uint64_t> contents = cgroups2::read<uint64_t>(
+      cgroup, memory::control::PEAK);
+  if (contents.isError()) {
+    return Error("Failed to read 'memory.peak': " + contents.error());
   }
 
   return Bytes(*contents);

--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -328,6 +328,12 @@ process::Future<Nothing> oom(const std::string& cgroup);
 Try<Bytes> usage(const std::string& cgroup);
 
 
+// Maximum memory usage for the cgroup and its descendants since creation.
+//
+// Cannot be used for the root cgroup.
+Try<Bytes> peak_usage(const std::string& cgroup);
+
+
 // Set the best-effort memory protection for a cgroup and its descendants. If
 // there is memory contention and this cgroup is within the 'low' threshold,
 // then memory will be reclaimed from other cgroups (without memory protection)

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -326,8 +326,10 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_MemoryUsage)
 
   // Does not exist for the root cgroup.
   EXPECT_ERROR(cgroups2::memory::usage(cgroups2::ROOT_CGROUP));
+  EXPECT_ERROR(cgroups2::memory::peak_usage(cgroups2::ROOT_CGROUP));
 
   EXPECT_SOME(cgroups2::memory::usage(TEST_CGROUP));
+  EXPECT_SOME(cgroups2::memory::peak_usage(TEST_CGROUP));
 }
 
 


### PR DESCRIPTION
The cgroups2 control file `memory.peak` contains the maximum recorded memory usage for a cgroup and its descendants since creation.

Here we introduce `cgroups2::memory::peak_usage` to read this maximum.

---


`memory.peak` doesn’t always exist. It was introduced in May 2022 and was backported into RHEL 9.3 but our CentOS 9 distribution doesn’t use it.

src: https://stackoverflow.com/questions/66291245/is-it-possible-to-implement-max-usage-in-bytes-for-cgroup-v2