### PR TITLE
[cgroups2] Made `cgroups2::processes` optionally recursive.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -93,7 +93,11 @@ Try<std::string> cgroup(pid_t pid);
 
 
 // Get the processes inside of a cgroup.
-Try<std::set<pid_t>> processes(const std::string& cgroup);
+//
+// Optionally fetch all of the processes in the cgroup subtree by setting
+// recursive=true. This will include all processes in nested cgroups.
+Try<std::set<pid_t>> processes(
+    const std::string& cgroup, bool recursive = false);
 
 
 // Get the threads inside of a cgroup.

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -185,6 +185,11 @@ TEST_F(Cgroups2Test, ROOT_CGROUPS2_AssignProcesses)
   EXPECT_EQ(1u, pids->size());
   EXPECT_EQ(pid, *pids->begin());
 
+  // Should fetch the `pid` from the nested `TEST_CGROUP` if `recursive=true`.
+  Try<set<pid_t>> root_pids = cgroups2::processes(cgroups2::ROOT_CGROUP, true);
+  EXPECT_SOME(pids);
+  EXPECT_EQ(1u, root_pids->count(pid));
+
   // Kill the child process.
   ASSERT_NE(-1, ::kill(pid, SIGKILL));
   AWAIT_EXPECT_WTERMSIG_EQ(SIGKILL, process::reap(pid));


### PR DESCRIPTION
Previously, `cgroups2::processes` could only fetch processes from inside of the provided cgroup. We can now fetch all of the processes inside of a cgroup subtree by passing an (optional) `recursive` flag.

```c++
Try<std::set<pid_t>> processes(
    const std::string& cgroup,
    bool recursive = false);
```