### PR TITLE
[cgroups2] Update destroy to be async more robust.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -79,7 +79,7 @@ Try<Nothing> kill(const std::string& cgroup);
 
 // Recursively destroy a cgroup and all nested cgroups. Processes inside of
 // destroyed cgroups are killed with SIGKILL.
-Try<Nothing> destroy(const std::string& cgroup);
+process::Future<Nothing> destroy(const std::string& cgroup);
 
 
 // Assign a process to a cgroup, by PID, removing the process from its

--- a/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
+++ b/src/slave/containerizer/mesos/isolators/cgroups2/cgroups2.hpp
@@ -149,7 +149,7 @@ private:
 
   process::Future<Nothing> __cleanup(
       const ContainerID& containerId,
-      const std::vector<process::Future<Nothing>>& futures);
+      const process::Future<Nothing>& future);
 
   process::Owned<Cgroups2IsolatorProcess::Info> cgroupInfo(
       const ContainerID& containerId) const;

--- a/src/slave/containerizer/mesos/linux_launcher.cpp
+++ b/src/slave/containerizer/mesos/linux_launcher.cpp
@@ -112,7 +112,7 @@ private:
 
   Future<Nothing> destroyCgroups(const Container& container);
   Future<Nothing> _destroyCgroups(const Container& container);
-  Try<Nothing> destroyCgroups2(const Container& container);
+  Future<Nothing> destroyCgroups2(const Container& container);
 
   const Flags flags;
 
@@ -773,7 +773,7 @@ Future<Nothing> LinuxLauncherProcess::_destroyCgroups(
 }
 
 
-Try<Nothing> LinuxLauncherProcess::destroyCgroups2(
+Future<Nothing> LinuxLauncherProcess::destroyCgroups2(
   const Container& container)
 {
 #ifdef ENABLE_CGROUPS_V2
@@ -784,15 +784,7 @@ Try<Nothing> LinuxLauncherProcess::destroyCgroups2(
 
   LOG(INFO) << "Destroying cgroup '" << cgroup << "'";
 
-  Try<Nothing> destroy = cgroups2::destroy(cgroup);
-  if (destroy.isError()) {
-    return Error("Failed to destory cgroup '" + cgroup + "': "
-                 + destroy.error());
-  }
-
-  LOG(INFO) << "Destroyed container " << container.id;
-
-  return Nothing();
+  return cgroups2::destroy(cgroup);
 #else
   return Error("cgroups2 is not enabled");
 #endif // ENABLE_CGROUPS_V2

--- a/src/tests/containerizer/cgroups2_tests.cpp
+++ b/src/tests/containerizer/cgroups2_tests.cpp
@@ -95,14 +95,14 @@ protected:
     // Cleanup the test cgroup, in case a previous test run didn't clean it
     // up properly.
     if (cgroups2::exists(TEST_CGROUP)) {
-      ASSERT_SOME(cgroups2::destroy(TEST_CGROUP));
+      AWAIT_READY(cgroups2::destroy(TEST_CGROUP));
     }
   }
 
   void TearDown() override
   {
     if (cgroups2::exists(TEST_CGROUP)) {
-      ASSERT_SOME(cgroups2::destroy(TEST_CGROUP));
+      AWAIT_READY(cgroups2::destroy(TEST_CGROUP));
     }
 
     ASSERT_SOME(cgroups2::controllers::disable(


### PR DESCRIPTION
We were running into an inconsistent issue with `cgroups2::destroy`.
`cgroups2::destroy` would fail with EBUSY when removing cgroups with `rmdir`.
The error was being caused because some processes had not been killed
when `rmdir` was called on their cgroup; a cgroup with processes
cannot be destroyed.

After signalling a kill (by writing "1" to 'cgroup.kill') sometimes
processes were staying alive long enough to cause `rmdir` to fail.

Hence, we update `cgroups2::destroy` to wait after signalling a
SIGKILL for all the processes to drop before attempting to remove
the cgroups.

Since we wait a maximum of half a second, we don't want to block the
caller. Thus, we update `destroy` to be async.