### PR TITLE
[cgroups2] Supplement missing 'kernel' field in 'memory.stat' with other kernel fields.

### DIFF
--- a/src/linux/cgroups2.hpp
+++ b/src/linux/cgroups2.hpp
@@ -267,6 +267,9 @@ struct Stats
 
   // Amount of total kernel memory, including (kernel_stack, pagetables,
   // percpu, vmalloc, slab) in addition to other kernel memory use cases.
+  //
+  // If this field is missing (Kernel version < 5.18), it's calculated as
+  // the sum of: kernel_stack, pagetables, sock, vmalloc, and slab.
   Bytes kernel;
 
   // Amount of memory allocated to kernel stacks.
@@ -283,6 +286,9 @@ struct Stats
 
   // Amount of cached filesystem data mapped with mmap().
   Bytes file_mapped;
+
+  // Amount of memory used for storing in-kernel data structures.
+  Bytes slab;
 };
 
 


### PR DESCRIPTION
The 'kernel' key was introduces to 'memory.stat' in Kernel 5.18 and therefore may be missing. If it is missing, we set `kernel` in `cgroups2::memory::Stats` to be the sum of the other kernel usage fields provided in 'memory.stat'.

As part of this, we add the 'slab' key (one of the kernel memory usage fields) to the `memory::Stats` structure.

---
Kernel patch introducing 'kernel': https://github.com/torvalds/linux/commit/a8c49af3be5f0b4e105ef678bcf14ef102c270be