### PR TITLE
FIX: Add missing source file in cgroups list.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,10 +349,11 @@ if (ENABLE_XFS_DISK_ISOLATOR)
     slave/containerizer/mesos/isolators/xfs/utils.cpp)
 endif ()
 
-if (ENABLE_CGROUPS_v2)
+if (ENABLE_CGROUPS_V2)
   list(APPEND LINUX_SRC
     linux/cgroups2.cpp
     linux/ebpf.cpp
+    slave/containerizer/mesos/isolators/cgroups2/cgroups2.cpp
     slave/containerizer/mesos/isolators/cgroups2/controller.cpp
     slave/containerizer/mesos/isolators/cgroups2/controllers/core.cpp
     slave/containerizer/mesos/isolators/cgroups2/controllers/cpu.cpp


### PR DESCRIPTION
The building via cmake will fail if cgroups v2 is enabled. That's because of a missing file in the source list. 