### PR TITLE
Add support for docker network options

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -833,12 +833,12 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
   ContainerInfo::DockerInfo::Network network;
   if (dockerInfo.has_network()) {
     network = dockerInfo.network();
-  } else {
-    // If no network was given, then use the OS specific default.
+  } else if (!options.network.isSome()) {
+    // If no network and no docker network options was given, then use the OS specific default.    
 #ifdef __WINDOWS__
-    network = ContainerInfo::DockerInfo::BRIDGE;
+      network = ContainerInfo::DockerInfo::BRIDGE;
 #else
-    network = ContainerInfo::DockerInfo::HOST;
+      network = ContainerInfo::DockerInfo::HOST;
 #endif // __WINDOWS__
   }
 


### PR DESCRIPTION
Short:

With these PR I want to add support for custom docker networks created by `docker network ...`

Long:

The Mesos DockerInfo Network object only supports four network modes: BRIDGE, HOST, USER, and NONE. If we want to use a network created by the Docker command docker network create ..., we cannot use the network mode. In that case, we have to add the DockerInfo parameter. The problem is, if we do not add a DockerInfo network mode, then the Docker executor will add a default one (Lines 839, 841). This means the Docker executor will try to run the container with two network parameters. Newer Docker engines do not accept this. To address this, my idea is to only add a default network mode if DockerInfo has no network and also no network parameter.
