### PR TITLE
Revert "Add support for docker network options"

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -833,12 +833,12 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
   ContainerInfo::DockerInfo::Network network;
   if (dockerInfo.has_network()) {
     network = dockerInfo.network();
-  } else if (!options.network.isSome()) {
-    // If no network and no docker network options was given, then use the OS specific default.    
+  } else {
+    // If no network was given, then use the OS specific default.
 #ifdef __WINDOWS__
-      network = ContainerInfo::DockerInfo::BRIDGE;
+    network = ContainerInfo::DockerInfo::BRIDGE;
 #else
-      network = ContainerInfo::DockerInfo::HOST;
+    network = ContainerInfo::DockerInfo::HOST;
 #endif // __WINDOWS__
   }
 


### PR DESCRIPTION
Reverts apache/mesos#583

Broke the build by making network un-intialized, will revert until a new
patch arrives.