### PR TITLE
CHANGE: add default network if no net options was set.

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -947,18 +947,26 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
   options.name = name;
 
   bool dnsSpecified = false;
+  bool networkSpecified = false;
   foreach (const Parameter& parameter, dockerInfo.parameters()) {
-    options.additionalOptions.push_back(
-        "--" + parameter.key() + "=" + parameter.value());
-
-    // In Docker 1.13.0, `--dns-option` was added and `--dns-opt` was hidden
-    // (but it can still be used), so here we need to check both of them.
-    if (!dnsSpecified &&
-        (parameter.key() == "dns" ||
-         parameter.key() == "dns-search" ||
-         parameter.key() == "dns-opt" ||
-         parameter.key() == "dns-option")) {
-      dnsSpecified = true;
+    if (!networkSpecified && 
+        (parameter.key() == "net" || 
+         parameter.key() == "network")) {
+      options.network = parameter.value();
+      networkSpecified = true;
+    } else {
+      options.additionalOptions.push_back(
+          "--" + parameter.key() + "=" + parameter.value());
+  
+      // In Docker 1.13.0, `--dns-option` was added and `--dns-opt` was hidden
+      // (but it can still be used), so here we need to check both of them.
+      if (!dnsSpecified &&
+          (parameter.key() == "dns" ||
+           parameter.key() == "dns-search" ||
+           parameter.key() == "dns-opt" ||
+           parameter.key() == "dns-option")) {
+        dnsSpecified = true;
+      }
     }
   }
 


### PR DESCRIPTION
Short:

With these PR I want to add support for custom docker networks created by docker network ...

Long:

The Mesos DockerInfo Network object only supports four network modes: BRIDGE, HOST, USER, and NONE. If we want to use a network created by the Docker command docker network create ..., we cannot use the network mode. In that case, we have to add the DockerInfo parameter. The problem is, if we do not add a DockerInfo network mode, then the Docker executor will add a default one (Lines 839, 841). This means the Docker executor could try to run the container with two incompatible network modes. With this PR the docker-executor will check if there is one (or many) `--net` or a `--network` parameters. If it's so, it will use the first one as default network mode and all others as additional. 

As example, the docker inspect on a container with two networks will looks like that:

```json
            "Networks": {
                "test": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": [
                        "60abf484d0f9"
                    ],
                    "MacAddress": "02:42:ac:12:00:02",
                    "NetworkID": "5556742fbb49569bd0e3b9219564e6db7d00e29ccc01e7eba63d0ee7a3054868",
                    "EndpointID": "b4bccb21281417ad65e4cad7703585c27039c611bee93115af8a72650eacdc0e",
                    "Gateway": "172.18.0.1",
                    "IPAddress": "172.18.0.2",
                    "IPPrefixLen": 16,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "DriverOpts": null,
                    "DNSNames": [
                        "mesos-fa5fdb98-10c3-479d-907f-3b95ccd9f42d",
                        "60abf484d0f9"
                    ]
                },
                "test2": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": [
                        "60abf484d0f9"
                    ],
                    "MacAddress": "02:42:ac:13:00:02",
                    "NetworkID": "185bca7da0a98d35ead37dbfb6b159f533448877eba269afaf229c1de0b17401",
                    "EndpointID": "8ea16d6ded939908818259f9aa243131db8789e5fb690bfd09aae564f83c690b",
                    "Gateway": "172.19.0.1",
                    "IPAddress": "172.19.0.2",
                    "IPPrefixLen": 16,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "DriverOpts": null,
                    "DNSNames": [
                        "mesos-fa5fdb98-10c3-479d-907f-3b95ccd9f42d",
                        "60abf484d0f9"
                    ]
                }
            }
```

The mesos container info will looks like that:

```json
    "container": {
        "type": "DOCKER",
        "docker": {
            "image": "alpine:latest",
            "network": "BRIDGE",
            "privileged": false,
            "parameters": [
                {
                    "key": "network",
                    "value": "test"
                },
                {
                    "key": "network",
                    "value": "test2"
                }
            ],
            "force_pull_image": true
        },
        "network_infos": [
            {
                "ip_addresses": [
                    {
                        "protocol": "IPv4",
                        "ip_address": "172.18.0.2"
                    }
                ],
                "name": "test"
            }
        ],
```