### PR TITLE
ADD: cni support for the docker executor.

### DIFF
--- a/src/docker/executor.cpp
+++ b/src/docker/executor.cpp
@@ -331,7 +331,7 @@ public:
 
             bool useCNI = false;
 #ifdef __linux__  
-            if (network_cni_config_dir.size() > 0 && network_cni_plugins_dir.size() > 0) {
+            if (!network_cni_config_dir.empty() && !network_cni_plugins_dir.empty()) {
               Try<std::tuple<Subprocess, std::string>> cni = attachCNI(task);
               if (!cni.isError()) {
                 Subprocess cniSub = std::get<0>(cni.get());

--- a/src/docker/executor.hpp
+++ b/src/docker/executor.hpp
@@ -90,6 +90,20 @@ struct Flags : public virtual mesos::internal::logging::Flags
         "Cgroups feature flag to enable hard limits on CPU resources\n"
         "via the CFS bandwidth limiting subfeature.\n",
         false);
+
+    add(&Flags::network_cni_plugins_dir,
+        "network_cni_plugins_dir",
+        "A search path for CNI plugin binaries. The docker executer\n"
+        "will find CNI plugins under these set of directories so that\n"
+        "it can execute the plugins to add/delete container from the CNI\n"
+        "networks.");
+  
+    add(&Flags::network_cni_config_dir,
+      "network_cni_config_dir",
+      "Directory path of the CNI network configuration files. For each\n"
+      "network that containers launched in Mesos agent can connect to,\n"
+      "the operator should install a network configuration file in JSON\n"
+      "format in the specified directory.");        
   }
 
   Option<std::string> container;
@@ -100,6 +114,8 @@ struct Flags : public virtual mesos::internal::logging::Flags
   Option<std::string> launcher_dir;
   Option<std::string> task_environment;
   Option<std::string> default_container_dns;
+  Option<std::string> network_cni_plugins_dir;
+  Option<std::string> network_cni_config_dir;  
 
   bool cgroups_enable_cfs;
 
@@ -123,7 +139,9 @@ public:
       const std::string& launcherDir,
       const std::map<std::string, std::string>& taskEnvironment,
       const Option<ContainerDNSInfo>& defaultContainerDNS,
-      bool cgroupsEnableCfs);
+      bool cgroupsEnableCfs,
+      const std::string& network_cni_plugins_dir,
+      const std::string& network_cni_config_dir);      
 
   ~DockerExecutor() override;
 
@@ -158,6 +176,12 @@ public:
 
 private:
   process::Owned<DockerExecutorProcess> process;
+
+  void attachCNI(const TaskInfo& task);
+  void attachCNISuccess(const Try<process::Subprocess> sub);
+
+  Try<JSON::Object> getNetworkConfigJSON(const std::string& fname, NetworkInfo* netInfo);
+  Try<std::string> getNetworkConfigFile(const std::string& network, const std::string& path, NetworkInfo* netInfo);  
 };
 
 } // namespace docker {

--- a/src/docker/executor.hpp
+++ b/src/docker/executor.hpp
@@ -99,11 +99,11 @@ struct Flags : public virtual mesos::internal::logging::Flags
         "networks.");
   
     add(&Flags::network_cni_config_dir,
-      "network_cni_config_dir",
-      "Directory path of the CNI network configuration files. For each\n"
-      "network that containers launched in Mesos agent can connect to,\n"
-      "the operator should install a network configuration file in JSON\n"
-      "format in the specified directory.");        
+        "network_cni_config_dir",
+        "Directory path of the CNI network configuration files. For each\n"
+        "network that containers launched in Mesos agent can connect to,\n"
+        "the operator should install a network configuration file in JSON\n"
+        "format in the specified directory.");        
   }
 
   Option<std::string> container;

--- a/src/launcher/docker_executor.cpp
+++ b/src/launcher/docker_executor.cpp
@@ -148,6 +148,14 @@ int main(int argc, char** argv)
       << flags.usage("Missing required option --mapped_directory");
   }
 
+  if (flags.network_cni_plugins_dir.isNone()) {
+      flags.network_cni_plugins_dir = "/usr/lib/cni/";
+  }
+
+  if (flags.network_cni_config_dir.isNone()) {
+      flags.network_cni_config_dir = "/etc/mesos/cni/net.d";
+  }
+
   map<string, string> taskEnvironment;
   if (flags.task_environment.isSome()) {
     // Parse the string as JSON.
@@ -245,7 +253,9 @@ int main(int argc, char** argv)
           flags.launcher_dir.get(),
           taskEnvironment,
           defaultContainerDNS,
-          flags.cgroups_enable_cfs));
+          flags.cgroups_enable_cfs,
+          flags.network_cni_plugins_dir.get(),
+          flags.network_cni_config_dir.get()));
 
   Owned<mesos::MesosExecutorDriver> driver(
       new mesos::MesosExecutorDriver(executor.get()));

--- a/src/launcher/docker_executor.cpp
+++ b/src/launcher/docker_executor.cpp
@@ -148,14 +148,6 @@ int main(int argc, char** argv)
       << flags.usage("Missing required option --mapped_directory");
   }
 
-  if (flags.network_cni_plugins_dir.isNone()) {
-      flags.network_cni_plugins_dir = "/usr/lib/cni/";
-  }
-
-  if (flags.network_cni_config_dir.isNone()) {
-      flags.network_cni_config_dir = "/etc/mesos/cni/net.d";
-  }
-
   map<string, string> taskEnvironment;
   if (flags.task_environment.isSome()) {
     // Parse the string as JSON.

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -255,6 +255,8 @@ DockerContainerizer::~DockerContainerizer()
   dockerFlags.mapped_directory = flags.sandbox_directory;
   dockerFlags.docker_socket = flags.docker_socket;
   dockerFlags.launcher_dir = flags.launcher_dir;
+  dockerFlags.network_cni_plugins_dir = flags.network_cni_plugins_dir;
+  dockerFlags.network_cni_config_dir = flags.network_cni_config_dir;  
 
   if (taskEnvironment.isSome()) {
     dockerFlags.task_environment = string(jsonify(taskEnvironment.get()));

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ list(APPEND MESOS_TESTS_SRC
   containerizer/containerizer_tests.cpp
   containerizer/cpu_isolator_tests.cpp
   containerizer/docker_containerizer_tests.cpp
+  containerizer/docker_cni_tests.cpp
   containerizer/docker_tests.cpp
   containerizer/memory_isolator_tests.cpp)
 

--- a/src/tests/containerizer/docker_cni_tests.cpp
+++ b/src/tests/containerizer/docker_cni_tests.cpp
@@ -1,0 +1,326 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY K:5IND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <gtest/gtest.h>
+
+#include <mesos/v1/mesos.hpp>
+#include <mesos/slave/container_logger.hpp>
+
+#include <process/owned.hpp>
+
+#include "slave/containerizer/docker.hpp"
+#include "slave/containerizer/fetcher.hpp"
+#include "slave/containerizer/mesos/isolators/network/cni/cni.hpp"
+
+#include "slave/paths.hpp"
+#include "slave/slave.hpp"
+#include "slave/state.hpp"
+
+#include "tests/flags.hpp"
+#include "tests/mesos.hpp"
+#include "tests/environment.hpp"
+#include "tests/containerizer/docker_common.hpp"
+#include "tests/mock_docker.hpp"
+
+
+using namespace process;
+
+using namespace mesos::internal::slave::paths;
+using namespace mesos::internal::slave::state;
+
+using mesos::internal::master::Master;
+using mesos::internal::slave::DockerContainerizer;
+using mesos::internal::slave::DockerContainerizerProcess;
+using mesos::internal::slave::Fetcher;
+using mesos::internal::slave::Slave;
+
+using mesos::master::detector::MasterDetector;
+
+using mesos::slave::ContainerConfig;
+using mesos::slave::ContainerLogger;
+using mesos::slave::ContainerTermination;
+
+using std::list;
+using std::string;
+using std::vector;
+
+using testing::_;
+using testing::DoAll;
+using testing::DoDefault;
+using testing::Eq;
+using testing::Invoke;
+using testing::Return;
+
+namespace mesos {
+namespace internal {
+namespace tests {
+
+constexpr char MESOS_MOCK_CNI_CONFIG[] = "mockConfig";
+
+
+static ContainerInfo createDockerInfo(const string& imageName)
+{
+    ContainerInfo containerInfo;
+
+    containerInfo.set_type(ContainerInfo::DOCKER);
+    containerInfo.mutable_docker()->set_image(imageName);
+
+    return containerInfo;
+}
+
+class DockerCniTest : public MesosTest
+{
+public:
+    string cniPluginDir;
+    string cniConfigDir;
+
+    void SetUp() override
+    {
+        MesosTest::SetUp();
+
+        cniPluginDir = path::join(sandbox.get(), "plugins");
+        cniConfigDir = path::join(sandbox.get(), "configs");
+
+        // This is a veth CNI plugin that is written in bash. It creates a
+        // veth virtual network pair, one end of the pair will be moved to
+        // container network namespace.
+        //
+        // The veth CNI plugin uses 203.0.113.0/24 subnet, it is reserved
+        // for documentation and examples [rfc5737]. The plugin can
+        // allocate up to 128 veth pairs.
+        Try<Nothing> result = setupMockPlugin(
+            strings::format(R"~(
+            #!/bin/sh
+            set -e
+            IP_ADDR="203.0.113.10/32"
+
+            NETNS="mesos-test-veth-${PPID}"
+            mkdir -p /var/run/netns
+            cleanup() {
+                rm -f /var/run/netns/$NETNS
+            }
+            trap cleanup EXIT
+            ln -sf $CNI_NETNS /var/run/netns/$NETNS
+
+            VETH0="vmesos1"
+            VETH1="eth0"
+
+            case $CNI_COMMAND in
+            "ADD"*)
+                ip link delete $VETH0 2>/dev/null || true
+                ip netns exec $NETNS ip link delete $VETH1 2>/dev/null || true
+
+                ip link add name $VETH0 type veth peer name $VETH1 > /tmp/cni.log || continue
+                ip addr add "${IP_ADDR}" dev $VETH0 >> /tmp/cni.log
+                ip link set $VETH0 up
+                ip link set $VETH1 netns $NETNS
+                ip netns exec $NETNS ip addr add "${IP_ADDR}" dev $VETH1
+                ip netns exec $NETNS ip link set $VETH1 up
+
+                echo "{"
+                echo "  \"ip4\": {"
+                echo "    \"ip\": \"${IP_ADDR}\""
+                echo "  },"
+                echo "  \"dns\": {"
+                echo "    \"nameservers\": [ \"8.8.8.8\" ]"
+                echo "  }"
+                echo "}"
+                ;;
+            "DEL"*)
+                # $VETH0 on host network namespace will be removed automatically.
+                # If the plugin can't destroy the veth pair, it will be destroyed
+                # with the container network namespace.
+                ip link delete $VETH0 2>/dev/null || true
+                ip netns exec $NETNS ip link del $VETH1 || true
+                ;;
+            esac
+            )~").get());
+
+        ASSERT_SOME(result);
+
+        // Generate the mock CNI config for veth CNI plugin.
+        ASSERT_SOME(os::mkdir(cniConfigDir));
+
+        result = os::write(
+            path::join(cniConfigDir, MESOS_MOCK_CNI_CONFIG),
+            R"~(
+            {
+            "name": "__MESOS_TEST__",
+            "type": "mockPlugin"
+            })~");
+    }
+
+    // Generate the mock CNI plugin based on the given script.
+    Try<Nothing> setupMockPlugin(const string& pluginScript)
+    {
+        return setupPlugin(pluginScript, "mockPlugin");
+    }
+
+    // Generate the CNI plugin based on the given script.
+    Try<Nothing> setupPlugin(const string& pluginScript, const string& pluginName)
+    {
+      Try<Nothing> mkdir = os::mkdir(cniPluginDir);
+      if (mkdir.isError()) {
+        return Error("Failed to mkdir '" + cniPluginDir + "': " + mkdir.error());
+      }
+
+      string pluginPath = path::join(cniPluginDir, pluginName);
+
+      Try<Nothing> write = os::write(pluginPath, pluginScript);
+      if (write.isError()) {
+        return Error("Failed to write '" + pluginPath + "': " + write.error());
+      }
+
+      // Make sure the plugin has execution permission.
+      Try<Nothing> chmod = os::chmod(
+          pluginPath,
+          S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+
+      if (chmod.isError()) {
+        return Error("Failed to chmod '" + pluginPath + "': " + chmod.error());
+      }
+
+      return Nothing();
+    }
+
+    static string containerName(const ContainerID& containerId)
+    {
+      return slave::DOCKER_NAME_PREFIX + containerId.value();
+    }
+
+protected:
+    slave::Flags CreateSlaveFlags() override
+    {
+        slave::Flags flags = MesosTest::CreateSlaveFlags();
+
+        flags.network_cni_plugins_dir = cniPluginDir;
+        flags.network_cni_config_dir = cniConfigDir;
+
+
+        return flags;
+    }
+};
+
+// This test tests the functionality of the docker's interfaces.
+TEST_F(DockerCniTest, ROOT_DOCKER_ip_interface)
+{
+    SetUp();
+
+    Try<Owned<cluster::Master>> master = StartMaster();
+    ASSERT_SOME(master);
+
+    MockDocker* mockDocker =
+      new MockDocker(tests::flags.docker, tests::flags.docker_socket);
+
+    Shared<Docker> docker(mockDocker);
+
+    slave::Flags flags = CreateSlaveFlags();
+
+    Fetcher fetcher(flags);
+
+    Try<ContainerLogger*> logger =
+      ContainerLogger::create(flags.container_logger);
+
+    ASSERT_SOME(logger);
+
+    MockDockerContainerizer dockerContainerizer(
+        flags,
+        &fetcher,
+        Owned<ContainerLogger>(logger.get()),
+        docker);
+
+    Owned<MasterDetector> detector = master.get()->createDetector();
+
+    Try<Owned<cluster::Slave>> slave =
+      StartSlave(detector.get(), &dockerContainerizer, flags);
+    ASSERT_SOME(slave);
+
+    MockScheduler sched;
+    MesosSchedulerDriver driver(
+        &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+
+    Future<FrameworkID> frameworkId;
+    EXPECT_CALL(sched, registered(&driver, _, _))
+      .WillOnce(FutureArg<1>(&frameworkId));
+
+    Future<vector<Offer>> offers;
+    EXPECT_CALL(sched, resourceOffers(&driver, _))
+      .WillOnce(FutureArg<1>(&offers))
+      .WillRepeatedly(Return()); // Ignore subsequent offers.
+
+    driver.start();
+
+    AWAIT_READY(frameworkId);
+
+    AWAIT_READY(offers);
+    ASSERT_FALSE(offers->empty());
+
+    TaskInfo task = createTask(
+        offers->front().slave_id(),
+        offers->front().resources(),
+        "sleep 10; ping 203.0.113.10 -c 1 -q");
+
+    ContainerInfo containerInfo = createDockerInfo("docker.io/alpine:latest");
+
+    containerInfo.mutable_docker()->set_network(
+        ContainerInfo::DockerInfo::BRIDGE);
+
+    task.mutable_container()->CopyFrom(containerInfo);
+    task.mutable_container()->add_network_infos()->set_name("__MESOS_TEST__");
+
+    Future<ContainerID> containerId;
+    Future<ContainerConfig> containerConfig;
+    EXPECT_CALL(dockerContainerizer, launch(_, _, _, _))
+      .WillOnce(DoAll(FutureArg<0>(&containerId),
+                      FutureArg<1>(&containerConfig),
+                      Invoke(&dockerContainerizer,
+                             &MockDockerContainerizer::_launch)));
+
+    Future<TaskStatus> statusStarting;
+    Future<TaskStatus> statusRunning;
+    Future<TaskStatus> statusFinished;
+    EXPECT_CALL(sched, statusUpdate(&driver, _))
+      .WillOnce(FutureArg<1>(&statusStarting))
+      .WillOnce(FutureArg<1>(&statusRunning))
+      .WillOnce(FutureArg<1>(&statusFinished))
+      .WillRepeatedly(DoDefault());
+
+    driver.launchTasks(offers.get()[0].id(), {task});
+
+    AWAIT_READY_FOR(containerId, Seconds(60));
+    AWAIT_READY_FOR(statusStarting, Seconds(60));
+    EXPECT_EQ(TASK_STARTING, statusStarting->state());
+    AWAIT_READY_FOR(statusRunning, Seconds(60));
+    EXPECT_EQ(TASK_RUNNING, statusRunning->state());
+    ASSERT_TRUE(statusRunning->has_data());
+    AWAIT_READY_FOR(statusFinished, Seconds(60));
+    EXPECT_EQ(TASK_FINISHED, statusFinished->state());
+
+    Future<Option<ContainerTermination>> termination =
+      dockerContainerizer.wait(containerId.get());
+
+    driver.stop();
+    driver.join();
+
+    AWAIT_READY(termination);
+    EXPECT_SOME(termination.get());
+}
+
+} // namespace tests
+} // namespace internal
+} // namespace mesos


### PR DESCRIPTION
With this PR I would like to add support for CNI (ContainerNetworkInterface) to the Docker Executor. As far as possible, I have followed the CNI implementation of the Mesos Containerizer. 
The following parameters and their default values are added to the Docker Executor:

- network_cni_plugins_dir: /usr/lib/cni/
- network_cni_config_dir: /etc/mesos/cni/net.d

**How is CNI used with Docker?**

By setting a name on the mesosproto NetworkInfo object which matches the CNI name in the CNI configuration.

Here is an example of a CNI configuration:

```
cat /etc/mesos/cni/net.d/10-mesos-net.conf
{
    "cniVersion": "0.2.0",
    "name": "mesos-net",
    "type": "ipvlan",
    "bridge": "cni0",
    "isGateway": true,
    "ipMasq": true,
    "vlanId": 5,
    "ipam": {
       "type": "host-local",
       "ranges": [
          [
            {
              "subnet": "10.10.0.0/16",
              "rangeStart": "10.10.0.10",
              "rangeEnd": "10.10.0.250"
            }
          ]
        ],
        "routes": [
            { "dst": "0.0.0.0/0" }
        ]
    }
}

```

**How does the Docker Executor work?**

If the name of the mesosproto NetworkInfo object has been set, the executor checks whether a CNI configuration exists for it. If this is the case, it is used to create a network interface in the container. If no CNI configuration exists, an error message appears in the stderr file in the sandbox directory. As the name can also be a Docker Network Plugin, the container is started in any case. If there is no Docker Network Plugin with the name, the container runs without an additional network interface. 

**How can the CNI support be tested?**

I have added a test that can be used via the Mesos Test Tool.

`mesos-tests --verbose --gtest_filter="DockerCniTest.*”`











